### PR TITLE
Configure pre-commit and contributor guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: ["--check"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-docstrings"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--strict"]
+  - repo: https://github.com/pre-commit/mirrors-pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+  - repo: https://github.com/myint/docformatter
+    rev: 1.7.5
+    hooks:
+      - id: docformatter
+        args: ["--in-place", "--wrap-summaries", "79"]
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: eslint
+        language: node
+        files: \.(js|jsx|ts|tsx)$
+        additional_dependencies: ["eslint"]
+        args: ["--max-warnings=0"]
+      - id: prettier
+        name: prettier
+        entry: prettier
+        language: node
+        files: \.(js|jsx|ts|tsx|css|scss|md)$
+        additional_dependencies: ["prettier"]
+        args: ["--check"]
+      - id: flow
+        name: flow
+        entry: flow
+        language: node
+        files: \.(js|jsx)$
+        additional_dependencies: ["flow-bin"]
+        args: ["check", "--show-all-errors"]
+      - id: stylelint
+        name: stylelint
+        entry: stylelint
+        language: node
+        files: \.(css|scss)$
+        additional_dependencies: ["stylelint"]
+        args: ["--max-warnings", "0"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+This project uses [pre-commit](https://pre-commit.com/) to automate code quality checks.
+To get started:
+
+1. Install the tool:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the git hooks:
+   ```bash
+   pre-commit install
+   ```
+
+The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Warnings are treated as errors, so commits will fail until issues are fixed.


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` with Python and JavaScript hooks
- document pre-commit installation in `CONTRIBUTING.md`

## Testing
- `pre-commit install` *(fails: asked for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_b_6877bf3554008331ad08b9d9e2c6a030