### PR TITLE
Configure Sphinx docs and CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Publish Docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx docformatter flake8 flake8-docstrings myst-parser sphinxcontrib-mermaid
+      - name: Build documentation
+        run: |
+          sphinx-build -b html -W docs docs/_build/html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs/_build/
+__pycache__/

--- a/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
+++ b/docs/blueprints/DesignIdeaEngineCompleteBlueprint.md
@@ -610,7 +610,7 @@ design-idea-engine-bucket/
 #### 2.3.2 Event Schema Design
 
 **Event Bus Message Format**:
-```json
+```
 {
   "eventType": "signal.ingested",
   "eventId": "uuid",
@@ -1370,34 +1370,34 @@ Design Idea Engine Blueprint.
 
 The blueprint provides a simplified ER diagram for the core data model. This will be translated into database schemas during implementation.
 
-```mermaid
-erDiagram
-    SIGNAL {
-      uuid id PK
-      text content
-      source ENUM
-      captured_at TIMESTAMP
-      metadata JSONB
-      hash CHAR(32) UNIQUE
-    }
-    IDEA ||--|| SIGNAL : derived_from
-    IDEA {
-      uuid id PK
-      title TEXT
-      embedding VECTOR(768)
-      score FLOAT
-      status ENUM(queued, mocked, live, archived)
-      created_at TIMESTAMP
-      updated_at TIMESTAMP
-    }
-    MOCKUP ||--|| IDEA : for
-    MOCKUP {
-      uuid id PK
-      s3_uri TEXT
-      variant ENUM(front, back, colorway)
-      ctr FLOAT
-    }
-```
+.. mermaid::
+
+   erDiagram
+       SIGNAL {
+         uuid id PK
+         text content
+         source ENUM
+         captured_at TIMESTAMP
+         metadata JSONB
+         hash CHAR(32) UNIQUE
+       }
+       IDEA ||--|| SIGNAL : derived_from
+       IDEA {
+         uuid id PK
+         title TEXT
+         embedding VECTOR(768)
+         score FLOAT
+         status ENUM(queued, mocked, live, archived)
+         created_at TIMESTAMP
+         updated_at TIMESTAMP
+       }
+       MOCKUP ||--|| IDEA : for
+       MOCKUP {
+         uuid id PK
+         s3_uri TEXT
+         variant ENUM(front, back, colorway)
+         ctr FLOAT
+       }
 
 ### 1.5 Key Takeaways from Blueprint
 
@@ -1867,7 +1867,7 @@ helm install prometheus prometheus-community/kube-prometheus-stack
 - `POST /api/publish` - Publish to marketplace
 
 ### Event Schema
-```json
+```
 {
   "eventType": "signal.ingested",
   "eventId": "uuid",
@@ -1896,11 +1896,11 @@ helm install prometheus prometheus-community/kube-prometheus-stack
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License.
 
 ## 🆘 Support
 
-- **Documentation**: [docs/](docs/)
+- **Documentation**: docs/
 - **Issues**: GitHub Issues
 - **Discussions**: GitHub Discussions
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+"""Sphinx configuration for the desAInz project."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+# -- Path setup --------------------------------------------------------------
+
+sys.path.insert(0, os.path.abspath(".."))
+
+# -- Project information -----------------------------------------------------
+
+project = "desAInz"
+author = "desAInz Team"
+release = "0.1"
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "myst_parser",
+    "sphinxcontrib.mermaid",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+templates_path = ["_templates"]
+exclude_patterns: list[str] = []
+
+# Treat warnings as errors
+nitpicky = True
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "alabaster"
+html_static_path = ["_static"]
+
+
+# -- Helper functions --------------------------------------------------------
+
+def _run_linters(app: "Sphinx") -> None:
+    """Run docformatter and flake8-docstrings before building docs."""
+    docs_dir = os.path.dirname(os.path.abspath(__file__))
+    subprocess.check_call(["docformatter", "--in-place", "--recursive", docs_dir])
+    subprocess.check_call(["flake8", "--select=D", docs_dir])
+
+
+def setup(app: "Sphinx") -> None:
+    """Set up Sphinx hooks."""
+    app.connect("builder-inited", _run_linters)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,9 @@
+Welcome to desAInz's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   README
+   blueprints/DesignIdeaEngineCompleteBlueprint


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish Sphinx docs on push to `main`
- create Sphinx configuration with autodoc & napoleon extensions
- run docformatter and flake8-docstrings as part of doc build
- include docs index file and update blueprint for Sphinx warnings
- ignore build artifacts

## Testing
- `flake8 docs/conf.py`
- `pydocstyle docs/conf.py`
- `docformatter --check docs/conf.py`
- `sphinx-build -b html -W docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_b_6877bf4808d08331828aa79903cdbf99