### PR TITLE
Add docker infrastructure files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+version: '3.8'
+
+services:
+  postgres:
+    build: ./docker/postgres
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "user"]
+      interval: 10s
+      retries: 5
+
+  redis:
+    build: ./docker/redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: 'yes'
+    volumes:
+      - zookeeper-data:/bitnami/zookeeper
+    healthcheck:
+      test: ["CMD", "zkServer.sh", "status"]
+      interval: 10s
+      retries: 5
+
+  kafka:
+    build: ./docker/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      retries: 5
+
+  minio:
+    build: ./docker/minio
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    command: server /data
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      retries: 5
+
+volumes:
+  postgres-data:
+  redis-data:
+  zookeeper-data:
+  kafka-data:
+  minio-data:

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,0 +1,5 @@
+FROM bitnami/kafka:latest
+
+EXPOSE 9092 9093
+
+HEALTHCHECK --interval=10s --retries=5 CMD kafka-topics.sh --bootstrap-server localhost:9092 --list > /dev/null

--- a/docker/minio/Dockerfile
+++ b/docker/minio/Dockerfile
@@ -1,0 +1,5 @@
+FROM minio/minio:latest
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=10s --retries=5 CMD mc ready local

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:15
+RUN apt-get update \
+    && apt-get install -y postgresql-15-pgvector \
+    && rm -rf /var/lib/apt/lists/*
+
+# Expose Postgres port
+EXPOSE 5432
+
+HEALTHCHECK --interval=10s --retries=5 CMD pg_isready -U "$POSTGRES_USER"

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,0 +1,5 @@
+FROM redis:7-alpine
+
+EXPOSE 6379
+
+HEALTHCHECK --interval=10s --retries=5 CMD redis-cli ping | grep PONG

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Simple script to block execution until required services respond on their ports
+
+set -euo pipefail
+
+services=("postgres:5432" "redis:6379" "kafka:9092" "minio:9000")
+
+for svc in "${services[@]}"; do
+    host="${svc%%:*}"
+    port="${svc##*:}"
+    echo "Waiting for $host:$port ..."
+    while ! nc -z "$host" "$port" >/dev/null 2>&1; do
+        sleep 1
+    done
+    echo "$host:$port is up"
+done


### PR DESCRIPTION
## Summary
- add Dockerfiles for postgres with pgvector, redis, kafka, and minio
- orchestrate services in `docker-compose.yml` with volumes and health checks
- add `scripts/wait-for-services.sh` helper for waiting on dependencies

## Testing
- `bash -n scripts/wait-for-services.sh`

------
https://chatgpt.com/codex/tasks/task_b_6877bf496b4883319421a31a09c46785