### PR TITLE
Add FastAPI service template

### DIFF
--- a/backend/service-template/pyproject.toml
+++ b/backend/service-template/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.poetry]
+name = "service-template"
+version = "0.1.0"
+description = "A FastAPI service template"
+authors = ["Your Name <you@example.com>"]
+packages = [{include = "", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "*"
+uvicorn = {extras = ["standard"], version = "*"}
+pydantic = "*"
+
+[tool.poetry.dev-dependencies]
+black = "*"
+flake8 = "*"
+flake8-docstrings = "*"
+flake8-builtins = "*"
+flake8-bugbear = "*"
+flake8-import-order = "*"
+docformatter = "*"
+pydocstyle = "*"
+mypy = "*"
+
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+
+[tool.mypy]
+strict = true
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/backend/service-template/src/__init__.py
+++ b/backend/service-template/src/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI service template package."""

--- a/backend/service-template/src/logging_config.py
+++ b/backend/service-template/src/logging_config.py
@@ -1,0 +1,51 @@
+"""Logging configuration for the service template."""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging.config import dictConfig
+from typing import Any, Dict
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Attach correlation IDs to log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add the ``correlation_id`` attribute if missing."""
+        record.correlation_id = getattr(record, "correlation_id", "-")
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Return the JSON representation of ``record``."""
+        log_record: Dict[str, Any] = {
+            "time": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+            "correlation_id": getattr(record, "correlation_id", None),
+        }
+        return json.dumps(log_record)
+
+
+def configure_logging() -> None:
+    """Configure JSON logging with correlation IDs."""
+    log_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {"correlation": {"()": CorrelationIdFilter}},
+        "formatters": {"json": {"()": JsonFormatter}},
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+                "filters": ["correlation"],
+            }
+        },
+        "root": {"handlers": ["default"], "level": "INFO"},
+    }
+    dictConfig(log_config)

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -1,0 +1,54 @@
+"""Entrypoint for the service template application."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Callable, Coroutine
+
+from fastapi import FastAPI, Request, Response
+
+from .logging_config import configure_logging
+from .settings import settings
+
+configure_logging()
+logger = logging.getLogger(__name__)
+app = FastAPI(title=settings.app_name)
+
+
+@app.middleware("http")
+async def add_correlation_id(
+    request: Request,
+    call_next: Callable[[Request], Coroutine[None, None, Response]],
+) -> Response:
+    """Ensure every request contains a correlation ID."""
+    correlation_id = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))
+    request.state.correlation_id = correlation_id
+
+    logger.info("request received", extra={"correlation_id": correlation_id})
+    response = await call_next(request)
+    response.headers["X-Correlation-ID"] = correlation_id
+    return response
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return service liveness."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Return service readiness."""
+    return {"status": "ready"}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=8000,
+        log_level=settings.log_level,
+    )

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -1,0 +1,20 @@
+"""Application settings loaded from environment variables."""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Store configuration derived from environment variables."""
+
+    app_name: str = "service-template"
+    log_level: str = "INFO"
+
+    class Config:
+        """Pydantic configuration for ``Settings``."""
+
+        env_file = ".env"
+
+
+settings = Settings()

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,10 @@ The `blueprints` folder contains a single comprehensive blueprint for the projec
 - [Design Idea Engine Complete Blueprint](blueprints/DesignIdeaEngineCompleteBlueprint.md)
 
 This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.
+
+## Service Template
+
+The `backend/service-template` directory contains a minimal FastAPI service. The
+application loads configuration from environment variables using
+`pydantic.BaseSettings`. Variables can be provided via a `.env` file. The
+`Settings` class is defined in `src/settings.py` and read on startup.


### PR DESCRIPTION
## Summary
- create a service template in `backend/service-template`
- implement `src/main.py` with `/health` and `/ready` endpoints
- add structured JSON logging with correlation ID support
- load environment settings via `pydantic.BaseSettings`
- document the new service in `docs/README.md`

## Testing
- `docformatter -i backend/service-template/src/*.py`
- `black backend/service-template/src`
- `flake8 backend/service-template/src`
- `pydocstyle backend/service-template/src`
- `mypy backend/service-template/src`
- `sphinx-build -b html docs docs/_build` *(fails: config directory doesn't contain a conf.py file)*
- `npx eslint '**/*.js'` *(fails: ESLint couldn't find a config file)*
- `npx prettier -c '**/*.{js,ts,tsx,css}'`
- `npx flow check` *(fails: could not determine executable to run)*
- `npx stylelint '**/*.css'` *(fails: No files matching the pattern were found)*

------
https://chatgpt.com/codex/tasks/task_b_6877bf4b32588331bc96b19e68dddcd1