### PR TITLE
Implement Feedback Loop Service with scheduling and A/B testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+docstring-convention = google
+ignore = E203,W503

--- a/backend/feedback-loop/feedback_loop/__init__.py
+++ b/backend/feedback-loop/feedback_loop/__init__.py
@@ -1,0 +1,13 @@
+"""Feedback Loop package."""
+
+from .ingestion import schedule_ingestion_jobs
+from .ab_test_manager import ABTestManager
+from .budget_adjuster import ThompsonBudgetAdjuster
+from .score_updater import schedule_score_update_job
+
+__all__ = [
+    "schedule_ingestion_jobs",
+    "ABTestManager",
+    "ThompsonBudgetAdjuster",
+    "schedule_score_update_job",
+]

--- a/backend/feedback-loop/feedback_loop/ab_test_manager.py
+++ b/backend/feedback-loop/feedback_loop/ab_test_manager.py
@@ -1,0 +1,60 @@
+"""A/B test manager using PostgreSQL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Optional
+
+from sqlalchemy import DateTime, Float, Integer, MetaData, String, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for declarative models."""
+
+    metadata = MetaData()
+
+
+class ABTestResult(Base):
+    """SQLAlchemy model for A/B test results."""
+
+    __tablename__ = "ab_test_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    variant: Mapped[str] = mapped_column(String, nullable=False)
+    reward: Mapped[float] = mapped_column(Float, nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+
+def get_engine(dsn: str):
+    """Create a SQLAlchemy engine."""
+    return create_engine(dsn)
+
+
+@dataclass
+class ABTestManager:
+    """Manage A/B test results storage."""
+
+    engine_dsn: str
+
+    def __post_init__(self) -> None:
+        """Initialize database engine and create tables."""
+        self.engine = get_engine(self.engine_dsn)
+        Base.metadata.create_all(self.engine)
+
+    def record_result(self, variant: str, reward: float, timestamp) -> None:
+        """Store a new A/B test result."""
+        with Session(self.engine) as session:
+            session.add(
+                ABTestResult(variant=variant, reward=reward, timestamp=timestamp)
+            )
+            session.commit()
+
+    def results(self, variant: Optional[str] = None) -> Iterable[ABTestResult]:
+        """Yield stored results filtered by variant if provided."""
+        with Session(self.engine) as session:
+            query = session.query(ABTestResult)
+            if variant:
+                query = query.filter_by(variant=variant)
+            yield from query.all()

--- a/backend/feedback-loop/feedback_loop/budget_adjuster.py
+++ b/backend/feedback-loop/feedback_loop/budget_adjuster.py
@@ -1,0 +1,40 @@
+"""Promotion budget adjustment using Thompson Sampling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+import numpy as np
+
+
+@dataclass
+class ThompsonBudgetAdjuster:
+    """Adjust promotion budgets based on A/B test results."""
+
+    priors: Dict[str, tuple[float, float]]
+    budgets: Dict[str, float]
+    results: Dict[str, list[int]] = field(default_factory=dict)
+
+    def update(self, variant: str, success: int) -> None:
+        """Record success/failure for a variant."""
+        self.results.setdefault(variant, []).append(success)
+
+    def sample(self) -> str:
+        """Sample a variant using Thompson Sampling."""
+        samples = {}
+        for variant, prior in self.priors.items():
+            alpha, beta = prior
+            successes = sum(self.results.get(variant, []))
+            failures = len(self.results.get(variant, [])) - successes
+            samples[variant] = np.random.beta(alpha + successes, beta + failures)
+        return max(samples, key=lambda k: samples[k])
+
+    def adjust_budgets(self) -> Dict[str, float]:
+        """Adjust budgets proportionally based on sampled variant."""
+        chosen = self.sample()
+        total_budget = sum(self.budgets.values())
+        adjusted = {k: 0.0 for k in self.budgets}
+        adjusted[chosen] = total_budget
+        self.budgets = adjusted
+        return adjusted

--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -1,0 +1,37 @@
+"""Metric ingestion scheduler."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def ingest_metrics() -> None:
+    """Ingest metrics from marketplaces."""
+    LOGGER.info("Ingesting metrics at %s", datetime.now(UTC).isoformat())
+    # Actual ingestion logic would go here
+
+
+def schedule_ingestion_jobs(
+    scheduler: BackgroundScheduler | None = None,
+) -> BackgroundScheduler:
+    """Schedule hourly metric ingestion jobs.
+
+    Parameters
+    ----------
+    scheduler:
+        Existing scheduler instance. If ``None``, a new one is created.
+
+    Returns
+    -------
+    BackgroundScheduler
+        Scheduler instance with the job added.
+    """
+    sched = scheduler or BackgroundScheduler()
+    sched.add_job(ingest_metrics, "interval", hours=1, id="metric_ingestion")
+    return sched

--- a/backend/feedback-loop/feedback_loop/score_updater.py
+++ b/backend/feedback-loop/feedback_loop/score_updater.py
@@ -1,0 +1,38 @@
+"""Nightly scoring weight updater."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Mapping
+
+import requests
+from apscheduler.schedulers.background import BackgroundScheduler
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def update_weights(api_url: str, weights: Mapping[str, float]) -> None:
+    """Update scoring weights via API."""
+    LOGGER.info("Updating weights at %s", datetime.now(UTC).isoformat())
+    response = requests.post(api_url, json={"weights": weights}, timeout=10)
+    response.raise_for_status()
+
+
+def schedule_score_update_job(
+    api_url: str,
+    weights: Mapping[str, float],
+    scheduler: BackgroundScheduler | None = None,
+) -> BackgroundScheduler:
+    """Schedule nightly weight update job."""
+    sched = scheduler or BackgroundScheduler()
+    sched.add_job(
+        update_weights,
+        "cron",
+        hour=0,
+        minute=0,
+        args=[api_url, weights],
+        id="score_weight_update",
+    )
+    return sched

--- a/backend/feedback-loop/main.py
+++ b/backend/feedback-loop/main.py
@@ -1,0 +1,28 @@
+"""Entry point to start scheduled jobs."""
+
+from __future__ import annotations
+
+import logging
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from feedback_loop import schedule_ingestion_jobs, schedule_score_update_job
+
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Start scheduler for feedback loop."""
+    scheduler = BackgroundScheduler()
+    schedule_ingestion_jobs(scheduler)
+    schedule_score_update_job(
+        "http://scoring-engine/api/weights", {"freshness": 1.0}, scheduler
+    )
+    scheduler.start()
+    LOGGER.info("Scheduler started")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,0 +1,39 @@
+"""Sphinx configuration for FeedbackLoop documentation."""
+
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[2] / "backend" / "feedback-loop")
+)
+
+project = "FeedbackLoop"
+copyright = "2025, Auto"
+author = "Auto"
+
+version = "0.1"
+release = "0.1"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]
+suppress_warnings = ["ref.ref"]

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,0 +1,15 @@
+FeedbackLoop documentation
+==========================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/sphinx/make.bat
+++ b/docs/sphinx/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -1,0 +1,14 @@
+Module Reference
+================
+
+.. automodule:: feedback_loop.ingestion
+   :members:
+
+.. automodule:: feedback_loop.ab_test_manager
+   :members:
+
+.. automodule:: feedback_loop.budget_adjuster
+   :members:
+
+.. automodule:: feedback_loop.score_updater
+   :members:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+black
+flake8
+mypy
+pydocstyle
+flake8-docstrings
+docformatter
+sphinx
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+APScheduler
+SQLAlchemy
+numpy
+requests
+psycopg2-binary

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+"""Test package for feedback loop."""
+
+import sys
+from pathlib import Path
+
+# Ensure feedback_loop package is discoverable
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "backend" / "feedback-loop")
+)

--- a/tests/test_budget_adjuster.py
+++ b/tests/test_budget_adjuster.py
@@ -1,0 +1,14 @@
+"""Tests for ThompsonBudgetAdjuster."""
+
+from feedback_loop.budget_adjuster import ThompsonBudgetAdjuster
+
+
+def test_budget_adjustment_monopolizes_budget() -> None:
+    """Budget should go entirely to sampled variant."""
+    adjuster = ThompsonBudgetAdjuster(
+        priors={"A": (1, 1), "B": (1, 1)}, budgets={"A": 50.0, "B": 50.0}
+    )
+    adjuster.update("A", 1)
+    adjusted = adjuster.adjust_budgets()
+    assert sum(adjusted.values()) == 100.0
+    assert list(adjusted.values()).count(0.0) == 1

--- a/tests/test_score_updater.py
+++ b/tests/test_score_updater.py
@@ -1,0 +1,19 @@
+"""Tests for score_updater."""
+
+from unittest import mock
+
+from feedback_loop.score_updater import schedule_score_update_job, update_weights
+
+
+def test_update_weights_calls_api() -> None:
+    """Ensure API call is made when updating weights."""
+    with mock.patch("requests.post") as post:
+        update_weights("http://example.com", {"w": 1.0})
+        post.assert_called_once()
+
+
+def test_schedule_job_returns_scheduler() -> None:
+    """Ensure scheduler is returned with job."""
+    sched = schedule_score_update_job("url", {"w": 1.0})
+    job = sched.get_job("score_weight_update")
+    assert job is not None


### PR DESCRIPTION
## Summary
- add Feedback Loop service skeleton with hourly metric ingestion
- integrate Thompson Sampling for promotion budget adjustment
- store A/B test results in PostgreSQL via SQLAlchemy
- implement nightly scoring weight update job
- document modules in new Sphinx docs
- add unit tests for budget and scoring updater

## Testing
- `flake8 backend tests docs/sphinx/conf.py`
- `pydocstyle backend/feedback-loop/feedback_loop/*.py backend/feedback-loop/main.py tests docs/sphinx/conf.py`
- `mypy --disable-error-code=import-untyped backend/feedback-loop/feedback_loop/*.py backend/feedback-loop/main.py tests`
- `pytest -W error`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html`

------
https://chatgpt.com/codex/tasks/task_b_6877bf5336b483319f47d7d1a7c8af30