### PR TITLE
Add monitoring service with Prometheus metrics

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503
+select = C,E,F,W,B,B950,D
+
+[tool:pytest]
+addopts = -ra

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.egg-info/

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package."""

--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring service package."""

--- a/backend/monitoring/app.py
+++ b/backend/monitoring/app.py
@@ -1,0 +1,75 @@
+"""Monitoring service exposing Prometheus metrics and basic endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, cast
+
+from flask import Flask, Response, jsonify
+from opentelemetry import trace
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from prometheus_client import CollectorRegistry, Counter, generate_latest
+
+
+app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]
+
+trace.set_tracer_provider(
+    TracerProvider(resource=Resource.create({SERVICE_NAME: "monitoring"}))
+)
+tracer = trace.get_tracer(__name__)
+span_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+provider = cast(TracerProvider, trace.get_tracer_provider())
+provider.add_span_processor(span_processor)
+
+registry = CollectorRegistry()
+REQUEST_COUNT = Counter(
+    "monitoring_request_count",
+    "Number of requests served",
+    ["endpoint"],
+    registry=registry,
+)
+
+
+@app.route("/metrics")
+def metrics() -> Response:
+    """Return Prometheus metrics."""
+    REQUEST_COUNT.labels(endpoint="metrics").inc()
+    data = generate_latest(registry)
+    return Response(data, mimetype="text/plain")
+
+
+@app.route("/overview")
+def overview() -> Response:
+    """Provide a simple system overview."""
+    REQUEST_COUNT.labels(endpoint="overview").inc()
+    info = {"status": "ok"}
+    return jsonify(info)
+
+
+@app.route("/analytics")
+def analytics() -> Response:
+    """Return placeholder analytics dashboard data."""
+    REQUEST_COUNT.labels(endpoint="analytics").inc()
+    data = {"visitors": 0}
+    return jsonify(data)
+
+
+@app.route("/logs")
+def logs() -> Response:
+    """Return the last few log lines."""
+    REQUEST_COUNT.labels(endpoint="logs").inc()
+    log_file = Path("monitoring.log")
+    lines: Iterable[str]
+    if log_file.exists():
+        lines = log_file.read_text().splitlines()[-10:]
+    else:
+        lines = []
+    return jsonify({"logs": list(lines)})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/backend/monitoring/requirements.txt
+++ b/backend/monitoring/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+prometheus-client
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-instrumentation-flask
+opentelemetry-exporter-otlp

--- a/backend/monitoring/tests/__init__.py
+++ b/backend/monitoring/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for monitoring package."""

--- a/backend/monitoring/tests/test_app.py
+++ b/backend/monitoring/tests/test_app.py
@@ -1,0 +1,21 @@
+"""Tests for the monitoring service."""
+
+from __future__ import annotations
+
+from backend.monitoring.app import app
+
+
+def test_overview_endpoint() -> None:
+    """Verify the overview endpoint returns the expected data."""
+    client = app.test_client()
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "ok"}
+
+
+def test_metrics_endpoint() -> None:
+    """Ensure metrics endpoint is reachable."""
+    client = app.test_client()
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert b"monitoring_request_count" in response.data

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,5 @@ The `blueprints` folder contains a single comprehensive blueprint for the projec
 - [Design Idea Engine Complete Blueprint](blueprints/DesignIdeaEngineCompleteBlueprint.md)
 
 This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.
+
+- [Monitoring Service](monitoring.md)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,12 @@
+# Monitoring Service
+
+This microservice exposes Prometheus metrics and provides simple endpoints for
+system overview, analytics, and log retrieval. It also integrates
+OpenTelemetry tracing.
+
+## Endpoints
+
+- `/metrics` &mdash; Prometheus metrics.
+- `/overview` &mdash; basic system status.
+- `/analytics` &mdash; placeholder analytics dashboard data.
+- `/logs` &mdash; last few log lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = "E203,W503"
+docstring-convention = "google"
+
+[tool.mypy]
+strict = true
+
+[tool.docformatter]
+wrap-summaries = 88
+wrap-descriptions = 88
+
+[mypy]
+files = "backend"
+


### PR DESCRIPTION
## Summary
- add backend monitoring service exposing Prometheus metrics
- provide overview, analytics and log endpoints
- integrate basic OpenTelemetry tracing
- configure Python formatting and linting via pyproject
- document monitoring service

## Testing
- `flake8 .`
- `mypy backend/monitoring`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6877bf54b4e48331b095014659dc084d