### PR TITLE
Add Kafka message schemas and utilities

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka:
+    image: confluentinc/cp-kafka:7.5.1
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.5.1
+    depends_on:
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+    ports:
+      - "8081:8081"
+    volumes:
+      - ../kafka_schemas:/schemas
+      - ./register_schemas.sh:/docker-entrypoint-initdb.d/register_schemas.sh

--- a/docker/register_schemas.sh
+++ b/docker/register_schemas.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 5
+SCHEMA_REGISTRY_URL="http://localhost:8081"
+for schema_file in /schemas/*.json; do
+  topic=$(basename "$schema_file" .json)
+  curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+    --data @"$schema_file" \
+    "$SCHEMA_REGISTRY_URL/subjects/${topic}-value/versions"
+done

--- a/docs/source/sphinx/Makefile
+++ b/docs/source/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/sphinx/conf.py
+++ b/docs/source/sphinx/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'desAInz'
+copyright = '2025, DesAInz'
+author = 'DesAInz'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../..'))
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/sphinx/index.rst
+++ b/docs/source/sphinx/index.rst
@@ -1,0 +1,19 @@
+.. desAInz documentation master file, created by
+   sphinx-quickstart on Wed Jul 16 15:06:23 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+desAInz documentation
+=====================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+

--- a/docs/source/sphinx/make.bat
+++ b/docs/source/sphinx/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/sphinx/modules.rst
+++ b/docs/source/sphinx/modules.rst
@@ -1,0 +1,8 @@
+Modules
+=======
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+
+   kafka_utils

--- a/kafka_schemas/feedback.json
+++ b/kafka_schemas/feedback.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Feedback",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "rating": {"type": "integer"},
+    "comment": {"type": "string"}
+  },
+  "required": ["id", "rating"]
+}

--- a/kafka_schemas/listings.json
+++ b/kafka_schemas/listings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Listing",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "url": {"type": "string", "format": "uri"},
+    "price": {"type": "number"},
+    "metadata": {"type": "object"}
+  },
+  "required": ["id", "url", "price"]
+}

--- a/kafka_schemas/mockups.json
+++ b/kafka_schemas/mockups.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mockup",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "image_url": {"type": "string", "format": "uri"},
+    "metadata": {"type": "object"}
+  },
+  "required": ["id", "image_url"]
+}

--- a/kafka_schemas/scores.json
+++ b/kafka_schemas/scores.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Score",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "score": {"type": "number"},
+    "details": {"type": "object"}
+  },
+  "required": ["id", "score"]
+}

--- a/kafka_schemas/signals.json
+++ b/kafka_schemas/signals.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Signal",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "type": {"type": "string"},
+    "payload": {"type": "object"}
+  },
+  "required": ["id", "type", "payload"]
+}

--- a/kafka_utils/__init__.py
+++ b/kafka_utils/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for producing and consuming typed Kafka messages."""
+
+from .config import TOPICS
+from .producer import MessageProducer
+from .consumer import MessageConsumer
+
+__all__ = ["TOPICS", "MessageProducer", "MessageConsumer"]

--- a/kafka_utils/config.py
+++ b/kafka_utils/config.py
@@ -1,0 +1,15 @@
+"""Kafka topic configuration constants."""
+
+SIGNALS_TOPIC = "signals"
+SCORES_TOPIC = "scores"
+MOCKUPS_TOPIC = "mockups"
+LISTINGS_TOPIC = "listings"
+FEEDBACK_TOPIC = "feedback"
+
+TOPICS = [
+    SIGNALS_TOPIC,
+    SCORES_TOPIC,
+    MOCKUPS_TOPIC,
+    LISTINGS_TOPIC,
+    FEEDBACK_TOPIC,
+]

--- a/kafka_utils/consumer.py
+++ b/kafka_utils/consumer.py
@@ -1,0 +1,53 @@
+"""Kafka message consumer with JSON Schema support."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from confluent_kafka import Consumer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.json_schema import JSONDeserializer
+from confluent_kafka.serialization import MessageField, SerializationContext
+
+
+class MessageConsumer:
+    """Consume typed messages from Kafka topics."""
+
+    def __init__(
+        self, brokers: str, schema_registry_url: str, group_id: str
+    ) -> None:
+        """Initialize consumer and schema registry."""
+        self._consumer = Consumer(
+            {
+                "bootstrap.servers": brokers,
+                "group.id": group_id,
+                "auto.offset.reset": "earliest",
+            }
+        )
+        self._schema_registry = SchemaRegistryClient(
+            {"url": schema_registry_url}
+        )
+
+    def consume(self, topic: str, handler: Callable[[Any], None]) -> None:
+        """Consume messages from the given topic and process using handler."""
+        self._consumer.subscribe([topic])
+        schema = self._schema_registry.get_latest_version(
+            f"{topic}-value"
+        ).schema
+        deserializer = JSONDeserializer(
+            schema.schema_str, self._schema_registry
+        )
+        try:
+            while True:
+                msg = self._consumer.poll(1.0)
+                if msg is None:
+                    continue
+                if msg.error():
+                    raise RuntimeError(msg.error())
+                value = deserializer(
+                    msg.value(),
+                    SerializationContext(msg.topic(), MessageField.VALUE),
+                )
+                handler(value)
+        finally:
+            self._consumer.close()

--- a/kafka_utils/producer.py
+++ b/kafka_utils/producer.py
@@ -1,0 +1,33 @@
+"""Kafka message producer with JSON Schema support."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from confluent_kafka import Producer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.json_schema import JSONSerializer
+from confluent_kafka.serialization import MessageField, SerializationContext
+
+
+class MessageProducer:
+    """Produce typed messages to Kafka topics."""
+
+    def __init__(self, brokers: str, schema_registry_url: str) -> None:
+        """Initialize producer and schema registry."""
+        self._producer = Producer({"bootstrap.servers": brokers})
+        self._schema_registry = SchemaRegistryClient(
+            {"url": schema_registry_url}
+        )
+
+    def produce(self, topic: str, value: Dict[str, Any]) -> None:
+        """Produce a JSON message using the schema from the registry."""
+        schema = self._schema_registry.get_latest_version(
+            f"{topic}-value"
+        ).schema
+        serializer = JSONSerializer(schema.schema_str, self._schema_registry)
+        serialized = serializer(
+            value, SerializationContext(topic, MessageField.VALUE)
+        )
+        self._producer.produce(topic, serialized)
+        self._producer.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 79
+
+[tool.flake8]
+ignore = ""
+max-line-length = 79
+extend-ignore = "E203,W503"
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+strict = true
+
+[tool.docformatter]
+wrap-summaries = 79
+wrap-descriptions = 79
+
+[tool.pydocstyle]
+convention = "google"
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -W error
+filterwarnings =
+    ignore:jsonschema.RefResolver is deprecated.*:DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+confluent-kafka==2.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration to allow absolute imports from project root."""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+"""Tests for Kafka topic configuration."""
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message="jsonschema.RefResolver is deprecated*",
+    category=DeprecationWarning,
+)
+
+from kafka_utils import TOPICS  # noqa: E402
+
+
+def test_topics_defined() -> None:
+    """Ensure all required topics are present."""
+    assert set(TOPICS) == {
+        "signals",
+        "scores",
+        "mockups",
+        "listings",
+        "feedback",
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""Tests for message producer and consumer instantiation."""
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message="jsonschema.RefResolver is deprecated*",
+    category=DeprecationWarning,
+)
+
+from kafka_utils import MessageConsumer, MessageProducer  # noqa: E402
+
+
+def test_producer_init() -> None:
+    """Producer initializes with given brokers and schema registry."""
+    producer = MessageProducer("localhost:9092", "http://localhost:8081")
+    assert producer is not None
+
+
+def test_consumer_init() -> None:
+    """Consumer initializes with given parameters."""
+    consumer = MessageConsumer(
+        "localhost:9092", "http://localhost:8081", "test"
+    )
+    assert consumer is not None


### PR DESCRIPTION
## Summary
- set up Schema Registry container and Kafka broker config
- add JSON message schemas for microservices
- implement typed Kafka producers and consumers
- document modules with Sphinx
- configure pytest to treat warnings as errors and add simple tests

## Testing
- `flake8 kafka_utils tests`
- `mypy kafka_utils tests`
- `pydocstyle kafka_utils tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877bf595c8c8331bc57b3844fb127c0