### PR TITLE
Setup Alembic skeleton and models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite
+.idea/
+.vscode/

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package."""

--- a/backend/abtests/__init__.py
+++ b/backend/abtests/__init__.py
@@ -1,0 +1,1 @@
+"""Package for abtests service."""

--- a/backend/abtests/models.py
+++ b/backend/abtests/models.py
@@ -1,0 +1,19 @@
+"""Models for A/B testing service."""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.shared.db.base import Base
+
+
+class ABTest(Base):
+    """Represents an A/B test variant."""
+
+    __tablename__ = "ab_tests"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    test_name: Mapped[str] = mapped_column(nullable=False)
+    variant: Mapped[str] = mapped_column(nullable=False)
+    metrics: Mapped[dict[str, float] | None] = mapped_column(JSON)

--- a/backend/ideas/__init__.py
+++ b/backend/ideas/__init__.py
@@ -1,0 +1,1 @@
+"""Package for ideas service."""

--- a/backend/ideas/models.py
+++ b/backend/ideas/models.py
@@ -1,0 +1,18 @@
+"""Models for ideas service."""
+
+from __future__ import annotations
+
+from sqlalchemy import Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.shared.db.base import Base
+
+
+class Idea(Base):
+    """Represents an idea."""
+
+    __tablename__ = "ideas"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)

--- a/backend/listings/__init__.py
+++ b/backend/listings/__init__.py
@@ -1,0 +1,1 @@
+"""Package for listings service."""

--- a/backend/listings/models.py
+++ b/backend/listings/models.py
@@ -1,0 +1,18 @@
+"""Models for listings service."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Numeric
+
+from backend.shared.db.base import Base
+
+
+class Listing(Base):
+    """Represents a listing."""
+
+    __tablename__ = "listings"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(nullable=False)
+    price: Mapped[float] = mapped_column(Numeric(scale=2), nullable=False)

--- a/backend/mockups/__init__.py
+++ b/backend/mockups/__init__.py
@@ -1,0 +1,1 @@
+"""Package for mockups service."""

--- a/backend/mockups/models.py
+++ b/backend/mockups/models.py
@@ -1,0 +1,22 @@
+"""Models for mockups service."""
+
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from backend.shared.db.base import Base
+
+
+class Mockup(Base):
+    """Represents a mockup for an idea."""
+
+    __tablename__ = "mockups"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    idea_id: Mapped[int] = mapped_column(  # noqa: E501
+        ForeignKey("ideas.id"), nullable=False
+    )
+    image_url: Mapped[str] = mapped_column(nullable=True)
+
+    idea = relationship("Idea")

--- a/backend/scoring/__init__.py
+++ b/backend/scoring/__init__.py
@@ -1,0 +1,1 @@
+"""Package for scoring service."""

--- a/backend/scoring/models.py
+++ b/backend/scoring/models.py
@@ -1,0 +1,18 @@
+"""Models for scoring service."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Float
+
+from backend.shared.db.base import Base
+
+
+class ScoringWeight(Base):
+    """Represents scoring weights."""
+
+    __tablename__ = "scoring_weights"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(nullable=False)
+    weight: Mapped[float] = mapped_column(Float, nullable=False)

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared backend utilities."""

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database utilities and migration setup."""

--- a/backend/shared/db/abtests/versions/abt0001_create_abtests_table.py
+++ b/backend/shared/db/abtests/versions/abt0001_create_abtests_table.py
@@ -1,0 +1,23 @@
+"""Create abtests table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "abt0001"
+down_revision = None
+branch_labels = ("abtests",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "abtests",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("abtests")

--- a/backend/shared/db/alembic.ini
+++ b/backend/shared/db/alembic.ini
@@ -1,0 +1,32 @@
+[alembic]
+script_location = backend/shared/db
+version_locations = \
+    %(here)s/signals/versions \
+    %(here)s/ideas/versions \
+    %(here)s/mockups/versions \
+    %(here)s/listings/versions \
+    %(here)s/scoring/versions \
+    %(here)s/abtests/versions
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/shared/db/base.py
+++ b/backend/shared/db/base.py
@@ -1,0 +1,5 @@
+"""Base declarative class for SQLAlchemy models."""
+
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/backend/shared/db/env.py
+++ b/backend/shared/db/env.py
@@ -1,0 +1,65 @@
+"""Alembic environment setup."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from backend.shared.db.base import Base
+from backend.signals import models as signals_models  # noqa: F401
+from backend.ideas import models as ideas_models  # noqa: F401
+from backend.mockups import models as mockups_models  # noqa: F401
+from backend.listings import models as listings_models  # noqa: F401
+from backend.scoring import models as scoring_models  # noqa: F401
+from backend.abtests import models as abtests_models  # noqa: F401
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section) or {},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/shared/db/ideas/versions/ide0001_create_ideas_table.py
+++ b/backend/shared/db/ideas/versions/ide0001_create_ideas_table.py
@@ -1,0 +1,23 @@
+"""Create ideas table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "ide0001"
+down_revision = None
+branch_labels = ("ideas",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "ideas",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("ideas")

--- a/backend/shared/db/listings/versions/lis0001_create_listings_table.py
+++ b/backend/shared/db/listings/versions/lis0001_create_listings_table.py
@@ -1,0 +1,23 @@
+"""Create listings table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "lis0001"
+down_revision = None
+branch_labels = ("listings",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "listings",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("listings")

--- a/backend/shared/db/mockups/versions/moc0001_create_mockups_table.py
+++ b/backend/shared/db/mockups/versions/moc0001_create_mockups_table.py
@@ -1,0 +1,23 @@
+"""Create mockups table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "moc0001"
+down_revision = None
+branch_labels = ("mockups",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "mockups",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("mockups")

--- a/backend/shared/db/scoring/versions/sco0001_create_scoring_table.py
+++ b/backend/shared/db/scoring/versions/sco0001_create_scoring_table.py
@@ -1,0 +1,23 @@
+"""Create scoring table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "sco0001"
+down_revision = None
+branch_labels = ("scoring",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "scoring",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("scoring")

--- a/backend/shared/db/signals/versions/sig0001_create_signals_table.py
+++ b/backend/shared/db/signals/versions/sig0001_create_signals_table.py
@@ -1,0 +1,23 @@
+"""Create signals table."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "sig0001"
+down_revision = None
+branch_labels = ("signals",)
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    op.create_table(
+        "signals",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_table("signals")

--- a/backend/signals/__init__.py
+++ b/backend/signals/__init__.py
@@ -1,0 +1,1 @@
+"""Package for signals service."""

--- a/backend/signals/models.py
+++ b/backend/signals/models.py
@@ -1,0 +1,18 @@
+"""Models for signals service."""
+
+from __future__ import annotations
+
+from sqlalchemy import Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.shared.db.base import Base
+
+
+class Signal(Base):
+    """Represents a signal."""
+
+    __tablename__ = "signals"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(nullable=False)
+    data: Mapped[str | None] = mapped_column(Text)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,11 @@
+"""Sphinx configuration for documentation generation."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+project = "Design Idea Engine"
+extensions = ["sphinx.ext.autodoc"]
+exclude_patterns: list[str] = []
+html_theme = "alabaster"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+Welcome to Design Idea Engine's documentation!
+===============================================
+
+.. automodule:: backend.signals.models
+    :members:
+
+.. automodule:: backend.ideas.models
+    :members:
+
+.. automodule:: backend.mockups.models
+    :members:
+
+.. automodule:: backend.listings.models
+    :members:
+
+.. automodule:: backend.scoring.models
+    :members:
+
+.. automodule:: backend.abtests.models
+    :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+sqlalchemy>=1.4
+alembic
+pytest
+flake8
+black
+mypy
+pydocstyle
+flake8-docstrings
+docformatter
+sphinx

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,16 @@
+"""Tests for model metadata compilation."""
+
+from sqlalchemy import create_engine
+from backend.shared.db.base import Base
+import backend.signals.models  # noqa: F401
+import backend.ideas.models  # noqa: F401
+import backend.mockups.models  # noqa: F401
+import backend.listings.models  # noqa: F401
+import backend.scoring.models  # noqa: F401
+import backend.abtests.models  # noqa: F401
+
+
+def test_create_all() -> None:
+    """Ensure tables can be created without errors."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- setup separate Alembic folders per service under `backend/shared/db`
- define SQLAlchemy models for signals, ideas, mockups, listings, scoring weights and A/B tests
- create initial migration scripts and example `alembic.ini`
- add simple Sphinx documentation and test

## Testing
- `docformatter -i $(find backend -name '*.py') docs/source/conf.py`
- `black backend tests docs/source/conf.py`
- `flake8 backend tests docs/source/conf.py`
- `mypy backend`
- `pydocstyle backend tests docs/source/conf.py`
- `PYTHONPATH=. pytest -q`
- `sphinx-build -b html docs/source docs/_build/html`
- `PYTHONPATH=. alembic -c backend/shared/db/alembic.ini heads`

------
https://chatgpt.com/codex/tasks/task_b_6877bf57d25c8331b4f0081193874510