### PR TITLE
Add integration test workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+.env.local
+*.egg-info/
+docs/_build/

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -1,0 +1,4 @@
+version: '3.8'
+services:
+  app:
+    command: bash scripts/run-integration-tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  app:
+    image: python:3.12-slim
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: tail -f /dev/null

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,8 @@
+project = 'desAInz'
+extensions = ['sphinx.ext.autodoc']
+exclude_patterns = ['_build']
+html_theme = 'alabaster'
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,14 @@
+Welcome to desAInz's documentation!
+===================================
+
+.. automodule:: ingestion
+   :members:
+
+.. automodule:: scoring
+   :members:
+
+.. automodule:: mockup
+   :members:
+
+.. automodule:: publishing
+   :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+requests
+vcrpy
+pytest
+black
+flake8
+flake8-docstrings
+mypy
+sphinx

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies
+pip install -q -r requirements.txt
+
+# Format check
+black --check src tests >/dev/null
+flake8 src tests
+mypy src tests
+
+# Build docs
+sphinx-build -W -b html docs docs/_build
+
+# Run tests treating warnings as errors
+PYTHONPATH=$(pwd)/src python -m pytest -W error tests/integration

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 88
+extend-ignore = D100,D104
+
+[mypy]
+python_version = 3.12
+ignore_missing_imports = True

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""desAInz package."""

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -1,0 +1,26 @@
+"""Data ingestion module."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import requests
+
+
+def fetch_signals(url: str) -> List[dict[str, Any]]:
+    """Fetch trending design signals from ``url``.
+
+    Parameters
+    ----------
+    url:
+        Endpoint returning JSON data.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Parsed list of signals.
+    """
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return [data] if isinstance(data, dict) else data

--- a/src/mockup.py
+++ b/src/mockup.py
@@ -1,0 +1,25 @@
+"""Mockup generation module."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+
+def generate_mockups(scored: List[dict[str, Any]]) -> List[dict[str, Any]]:
+    """Generate mockups from scored signals.
+
+    Parameters
+    ----------
+    scored:
+        Scored signals.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Signals with ``mockup`` field appended.
+    """
+    result = []
+    for item in scored:
+        mockup = f"mockup-for-{item.get('id')}"
+        result.append({**item, "mockup": mockup})
+    return result

--- a/src/publishing.py
+++ b/src/publishing.py
@@ -1,0 +1,20 @@
+"""Publishing module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+
+def publish(mockups: List[dict[str, Any]], path: str) -> None:
+    """Publish mockups by storing them in ``path``.
+
+    Parameters
+    ----------
+    mockups:
+        Generated mockups.
+    path:
+        Destination path for serialized data.
+    """
+    file_path = Path(path)
+    file_path.write_text(str(mockups))

--- a/src/scoring.py
+++ b/src/scoring.py
@@ -1,0 +1,26 @@
+"""Signal scoring module."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+
+def score_signals(signals: List[dict[str, Any]]) -> List[dict[str, Any]]:
+    """Score signals by length of ``title`` field.
+
+    Parameters
+    ----------
+    signals:
+        Signals to score.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Signals with an added ``score`` key.
+    """
+    scored = []
+    for item in signals:
+        title = str(item.get("title", ""))
+        score = len(title)
+        scored.append({**item, "score": score})
+    return scored

--- a/tests/integration/cassettes/ingestion.yaml
+++ b/tests/integration/cassettes/ingestion.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://proxy:8080/todos/1
+  response:
+    body:
+      string: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n
+        \ \"completed\": false\n}"
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      age:
+      - '20987'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cache-control:
+      - max-age=43200
+      cf-cache-status:
+      - HIT
+      cf-ray:
+      - 9602658d784f66dd-DFW
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 16 Jul 2025 15:05:15 GMT
+      etag:
+      - W/"53-hfEnumeNh6YirfjyjaujcOPPT+s"
+      expires:
+      - '-1'
+      nel:
+      - '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+      pragma:
+      - no-cache
+      report-to:
+      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=8eHNy0rEqFGvFTHfj0pbMZCDykFwhKenxz41iq4wM9I%3D\u0026sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d\u0026ts=1752052512"}],"max_age":3600}'
+      reporting-endpoints:
+      - heroku-nel="https://nel.heroku.com/reports?s=8eHNy0rEqFGvFTHfj0pbMZCDykFwhKenxz41iq4wM9I%3D&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&ts=1752052512"
+      server:
+      - envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin, Accept-Encoding
+      via:
+      - 2.0 heroku-router
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '60'
+      x-powered-by:
+      - Express
+      x-ratelimit-limit:
+      - '1000'
+      x-ratelimit-remaining:
+      - '999'
+      x-ratelimit-reset:
+      - '1752052536'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -1,0 +1,27 @@
+"""Integration tests for the full workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import vcr
+
+from src.ingestion import fetch_signals
+from src.mockup import generate_mockups
+from src.publishing import publish
+from src.scoring import score_signals
+
+CASSETTE = Path(__file__).parent / "cassettes" / "ingestion.yaml"
+
+
+@vcr.use_cassette(str(CASSETTE))
+def test_workflow(tmp_path: Path) -> None:
+    """Run ingestion, scoring, mockup generation and publishing."""
+    signals = fetch_signals("https://jsonplaceholder.typicode.com/todos/1")
+    scored = score_signals(signals)
+    mockups = generate_mockups(scored)
+    output_file = tmp_path / "result.txt"
+    publish(mockups, str(output_file))
+    assert output_file.exists()
+    content = output_file.read_text()
+    assert "mockup-for" in content


### PR DESCRIPTION
## Summary
- add `src` modules for ingestion, scoring, mockup and publishing
- implement integration tests with VCR
- configure docker-compose override for running tests
- provide helper script to run integration tests
- add Sphinx docs, lint configs and requirements

## Testing
- `bash scripts/run-integration-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_6877bf5f7fb8833191f5b149106550f5