### PR TITLE
Add Codex environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# desAInz
+
+This repository contains the desAInz project. Use `scripts/setup_codex.sh` to install dependencies and build the documentation in a Codex environment.
+
+```bash
+./scripts/setup_codex.sh
+```

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Setup script for preparing the desAInz environment on Codex.
+# Installs Python and Node dependencies and builds documentation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
+
+if command -v npm >/dev/null 2>&1; then
+  npm ci
+fi
+
+# Build Sphinx documentation
+python -m pip install sphinx myst-parser sphinxcontrib-mermaid
+sphinx-build -W -b html docs docs/_build/html
+


### PR DESCRIPTION
## Summary
- add `setup_codex.sh` to install deps and build Sphinx docs
- document the setup command in a new `README`

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `npm run lint` *(fails: Code style issues found)*
- `pre-commit run --files scripts/setup_codex.sh README.md` *(fails: network access to GitHub denied)*
- `pytest -q` *(fails: duplicate `[tool.mypy]` tables)*

------
https://chatgpt.com/codex/tasks/task_b_6877c741772483319fcc64fe0c195b8d