### PR TITLE
Add shared Alembic migrations and DB models

### DIFF
--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 import redis
 
 from datetime import datetime
@@ -19,7 +19,7 @@ redis_client = redis.Redis.from_url(REDIS_URL)
 
 
 @app.get("/weights")
-def read_weights():
+def read_weights() -> Response:
     """Return current weighting parameters."""
     weights = get_weights()
     return jsonify(
@@ -34,7 +34,7 @@ def read_weights():
 
 
 @app.put("/weights")
-def update_weights_endpoint():
+def update_weights_endpoint() -> Response:
     """Update weighting parameters via JSON payload."""
     data = request.get_json(force=True)
     weights = update_weights(**data)
@@ -50,7 +50,7 @@ def update_weights_endpoint():
 
 
 @app.post("/score")
-def score_signal():
+def score_signal() -> Response:
     """Score a signal and cache hot results."""
     payload = request.get_json(force=True)
     key = json.dumps(payload, sort_keys=True)

--- a/backend/scoring-engine/scoring_engine/db.py
+++ b/backend/scoring-engine/scoring_engine/db.py
@@ -1,32 +1,7 @@
-"""Database setup and session handling."""
+"""Backward-compatible imports for shared DB utilities."""
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-import os
+from backend.shared.db import engine, session_scope
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///scoring.db")
-engine = create_engine(DATABASE_URL, echo=False, future=True)
-SessionLocal = sessionmaker(
-    bind=engine,
-    autoflush=False,
-    autocommit=False,
-    future=True,
-)
-
-
-@contextmanager
-def session_scope():
-    """Provide a transactional scope around a series of operations."""
-    session = SessionLocal()
-    try:
-        yield session
-        session.commit()
-    except Exception:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+__all__ = ["engine", "session_scope"]

--- a/backend/scoring-engine/scoring_engine/models.py
+++ b/backend/scoring-engine/scoring_engine/models.py
@@ -1,23 +1,8 @@
-"""SQLAlchemy models."""
+"""Re-export shared models for backwards compatibility."""
 
 from __future__ import annotations
 
-from sqlalchemy import Float, Integer
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from backend.shared.db.models import Weights
+from backend.shared.db.base import Base
 
-
-class Base(DeclarativeBase):
-    """Base class for ORM models."""
-
-
-class Weights(Base):
-    """Model storing scoring weights."""
-
-    __tablename__ = "weights"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    freshness: Mapped[float] = mapped_column(Float, default=1.0)
-    engagement: Mapped[float] = mapped_column(Float, default=1.0)
-    novelty: Mapped[float] = mapped_column(Float, default=1.0)
-    community_fit: Mapped[float] = mapped_column(Float, default=1.0)
-    seasonality: Mapped[float] = mapped_column(Float, default=1.0)
+__all__ = ["Weights", "Base"]

--- a/backend/scoring-engine/scoring_engine/weight_repository.py
+++ b/backend/scoring-engine/scoring_engine/weight_repository.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from sqlalchemy import select
 
-from .db import engine, session_scope
-from .models import Base, Weights
+from backend.shared.db import engine, session_scope
+from backend.shared.db.models import Weights
+from backend.shared.db.base import Base
 
 
 # Create table if not exists

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -1,0 +1,30 @@
+"""Database utilities shared across services."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .base import Base
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///shared.db")
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope for database operations."""
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/shared/db/alembic.ini
+++ b/backend/shared/db/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = backend/shared/db/migrations/scoring_engine
+sqlalchemy.url = sqlite:///shared.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/shared/db/base.py
+++ b/backend/shared/db/base.py
@@ -1,0 +1,9 @@
+"""SQLAlchemy base declarative class."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""

--- a/backend/shared/db/migrations/api_gateway/env.py
+++ b/backend/shared/db/migrations/api_gateway/env.py
@@ -1,0 +1,50 @@
+"""Alembic environment for the API gateway service."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from ... import engine
+from ...base import Base
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    url = str(engine.url)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py
@@ -1,0 +1,21 @@
+"""Initial placeholder migration for API gateway."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create initial tables placeholder."""
+    pass
+
+
+def downgrade() -> None:
+    """Drop placeholder tables."""
+    pass

--- a/backend/shared/db/migrations/scoring_engine/env.py
+++ b/backend/shared/db/migrations/scoring_engine/env.py
@@ -1,0 +1,50 @@
+"""Alembic environment for the scoring engine service."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from ... import engine
+from ...base import Base
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    url = str(engine.url)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py
@@ -1,0 +1,70 @@
+"""Create core tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tables."""
+    op.create_table(
+        "ideas",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "signals",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("idea_id", sa.Integer, sa.ForeignKey("ideas.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("engagement_rate", sa.Float(), nullable=False),
+        sa.Column("details", sa.String(), nullable=True),
+    )
+    op.create_table(
+        "mockups",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("idea_id", sa.Integer, sa.ForeignKey("ideas.id")),
+        sa.Column("image_url", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "listings",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("mockup_id", sa.Integer, sa.ForeignKey("mockups.id")),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "weights",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("freshness", sa.Float(), nullable=False, server_default="1"),
+        sa.Column("engagement", sa.Float(), nullable=False, server_default="1"),
+        sa.Column("novelty", sa.Float(), nullable=False, server_default="1"),
+        sa.Column("community_fit", sa.Float(), nullable=False, server_default="1"),
+        sa.Column("seasonality", sa.Float(), nullable=False, server_default="1"),
+    )
+    op.create_table(
+        "ab_tests",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("listing_id", sa.Integer, sa.ForeignKey("listings.id")),
+        sa.Column("variant", sa.String(length=50), nullable=False),
+        sa.Column("conversion_rate", sa.Float(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    """Drop tables."""
+    op.drop_table("ab_tests")
+    op.drop_table("weights")
+    op.drop_table("listings")
+    op.drop_table("mockups")
+    op.drop_table("signals")
+    op.drop_table("ideas")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -1,0 +1,91 @@
+"""Shared SQLAlchemy models used across services."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class Idea(Base):
+    """Represents a generated idea."""
+
+    __tablename__ = "ideas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    signals: Mapped[list["Signal"]] = relationship(back_populates="idea")
+    mockups: Mapped[list["Mockup"]] = relationship(back_populates="idea")
+
+
+class Signal(Base):
+    """Metric signal associated with an idea."""
+
+    __tablename__ = "signals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    idea_id: Mapped[int] = mapped_column(ForeignKey("ideas.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    engagement_rate: Mapped[float] = mapped_column(Float)
+    details: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    idea: Mapped[Idea] = relationship(back_populates="signals")
+
+
+class Mockup(Base):
+    """Visual mockup for an idea."""
+
+    __tablename__ = "mockups"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    idea_id: Mapped[int] = mapped_column(ForeignKey("ideas.id"))
+    image_url: Mapped[str] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    idea: Mapped[Idea] = relationship(back_populates="mockups")
+    listings: Mapped[list["Listing"]] = relationship(back_populates="mockup")
+
+
+class Listing(Base):
+    """Marketplace listing for a mockup."""
+
+    __tablename__ = "listings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    mockup_id: Mapped[int] = mapped_column(ForeignKey("mockups.id"))
+    price: Mapped[float] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    mockup: Mapped[Mockup] = relationship(back_populates="listings")
+    tests: Mapped[list["ABTest"]] = relationship(back_populates="listing")
+
+
+class Weights(Base):
+    """Scoring weight parameters."""
+
+    __tablename__ = "weights"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    freshness: Mapped[float] = mapped_column(Float, default=1.0)
+    engagement: Mapped[float] = mapped_column(Float, default=1.0)
+    novelty: Mapped[float] = mapped_column(Float, default=1.0)
+    community_fit: Mapped[float] = mapped_column(Float, default=1.0)
+    seasonality: Mapped[float] = mapped_column(Float, default=1.0)
+
+
+class ABTest(Base):
+    """A/B test configuration."""
+
+    __tablename__ = "ab_tests"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    listing_id: Mapped[int] = mapped_column(ForeignKey("listings.id"))
+    variant: Mapped[str] = mapped_column(String(50))
+    conversion_rate: Mapped[float] = mapped_column(Float, default=0.0)
+
+    listing: Mapped[Listing] = relationship(back_populates="tests")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,8 @@ extend-ignore = ["E203", "W503"]
 docstring-convention = "google"
 
 [tool.mypy]
-python_version = "3.12"
-ignore_missing_imports = true
-extend-ignore = []
-show-source = true
-
-[tool.mypy]
 python_version = "3.11"
+ignore_missing_imports = true
 check_untyped_defs = true
 disallow_untyped_defs = true
 disallow_any_generics = true


### PR DESCRIPTION
## Summary
- establish shared SQLAlchemy models and session management
- provide Alembic configuration with separate migration folders
- add initial migrations for scoring engine and API gateway
- update scoring engine to use shared models and DB
- clean up mypy settings

## Testing
- `flake8 backend/scoring-engine/scoring_engine/app.py backend/scoring-engine/scoring_engine/db.py backend/scoring-engine/scoring_engine/models.py backend/scoring-engine/scoring_engine/weight_repository.py backend/shared/db/base.py backend/shared/db/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/env.py backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py backend/shared/db/migrations/api_gateway/env.py backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py pyproject.toml`
- `docformatter -i backend/scoring-engine/scoring_engine/app.py backend/shared/db/base.py backend/shared/db/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/env.py backend/shared/db/migrations/api_gateway/env.py backend/scoring-engine/scoring_engine/db.py backend/scoring-engine/scoring_engine/models.py backend/scoring-engine/scoring_engine/weight_repository.py backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py`
- `pydocstyle backend/scoring-engine/scoring_engine/app.py backend/shared/db/base.py backend/shared/db/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/env.py backend/shared/db/migrations/api_gateway/env.py backend/scoring-engine/scoring_engine/db.py backend/scoring-engine/scoring_engine/models.py backend/scoring-engine/scoring_engine/weight_repository.py backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py`
- `mypy backend/shared/db/base.py backend/shared/db/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/env.py backend/shared/db/migrations/scoring_engine/versions/0001_create_core_tables.py backend/shared/db/migrations/api_gateway/env.py backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py backend/scoring-engine/scoring_engine/db.py backend/scoring-engine/scoring_engine/models.py backend/scoring-engine/scoring_engine/weight_repository.py`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_b_6877c6fa77908331b721eaf7d7479e9d