### PR TITLE
Add monitoring service with Prometheus metrics and tracing

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -2,7 +2,10 @@
 
 from fastapi import FastAPI
 
+from backend.common.tracing import init_fastapi_tracing
+
 from .routes import router
 
 app = FastAPI(title="API Gateway")
+init_fastapi_tracing(app, "api-gateway")
 app.include_router(router)

--- a/backend/common/__init__.py
+++ b/backend/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for backend services."""

--- a/backend/common/tracing.py
+++ b/backend/common/tracing.py
@@ -1,0 +1,45 @@
+"""OpenTelemetry tracing configuration utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+
+def _configure_tracer(service_name: str) -> None:
+    """Configure the tracer provider for ``service_name``."""
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    processor = SimpleSpanProcessor(ConsoleSpanExporter())
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+
+
+def init_fastapi_tracing(app: Any, service_name: str) -> None:
+    """Instrument a FastAPI ``app`` for tracing."""
+    _configure_tracer(service_name)
+    FastAPIInstrumentor().instrument_app(app)
+
+
+def init_flask_tracing(app: Any, service_name: str) -> None:
+    """Instrument a Flask ``app`` for tracing."""
+    _configure_tracer(service_name)
+    try:
+        from opentelemetry.instrumentation.flask import FlaskInstrumentor
+    except Exception:  # pragma: no cover - Flask not installed
+        return
+    FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]
+
+
+def init_celery_tracing(app: Any, service_name: str) -> None:
+    """Instrument a Celery ``app`` for tracing."""
+    _configure_tracer(service_name)
+    try:
+        from opentelemetry.instrumentation.celery import CeleryInstrumentor
+    except Exception:  # pragma: no cover - Celery not installed
+        return
+    CeleryInstrumentor().instrument()

--- a/backend/mockup-generation/mockup_generation/celery_app.py
+++ b/backend/mockup-generation/mockup_generation/celery_app.py
@@ -6,7 +6,10 @@ import os
 
 from celery import Celery
 
+from backend.common.tracing import init_celery_tracing
+
 
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 app = Celery("mockup_generation", broker=CELERY_BROKER_URL)
+init_celery_tracing(app, "mockup-generation")
 app.conf.result_backend = CELERY_BROKER_URL

--- a/backend/monitoring/__init__.py
+++ b/backend/monitoring/__init__.py
@@ -1,0 +1,1 @@
+"""Monitoring service exposing metrics and logs."""

--- a/backend/monitoring/main.py
+++ b/backend/monitoring/main.py
@@ -1,0 +1,59 @@
+"""FastAPI application exposing monitoring endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Coroutine
+
+from fastapi import FastAPI, Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from backend.common.tracing import init_fastapi_tracing
+from .metrics import REQUEST_COUNT, REQUEST_LATENCY, prometheus_metrics
+
+app = FastAPI(title="Monitoring Service")
+init_fastapi_tracing(app, "monitoring")
+
+
+@app.middleware("http")
+async def track_metrics(
+    request: Request,
+    call_next: Callable[[Request], Coroutine[None, None, Response]],
+) -> Response:
+    """Record metrics for every request."""
+    REQUEST_COUNT.inc()
+    with REQUEST_LATENCY.time():
+        response = await call_next(request)
+    return response
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Return Prometheus metrics."""
+    return Response(prometheus_metrics(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/overview")
+async def overview() -> dict[str, str]:
+    """Return high-level system status information."""
+    return {"status": "operational"}
+
+
+@app.get("/analytics")
+async def analytics() -> dict[str, float]:
+    """Return aggregated analytics data."""
+    if REQUEST_COUNT._value.get() == 0:
+        latency = 0.0
+    else:
+        latency = REQUEST_LATENCY._sum.get() / REQUEST_COUNT._value.get()
+    return {"average_latency": latency}
+
+
+@app.get("/logs")
+async def logs() -> dict[str, str]:
+    """Return the latest log entries if available."""
+    log_path = Path("service.log")
+    if log_path.exists():
+        lines = log_path.read_text().splitlines()[-10:]
+        return {"logs": "\n".join(lines)}
+    return {"logs": ""}

--- a/backend/monitoring/metrics.py
+++ b/backend/monitoring/metrics.py
@@ -1,0 +1,27 @@
+"""Prometheus metrics utilities for the monitoring service."""
+
+from __future__ import annotations
+
+from prometheus_client import (
+    REGISTRY,
+    Counter,
+    Summary,
+    generate_latest,
+)
+
+registry = REGISTRY
+REQUEST_COUNT = Counter(
+    "request_count",
+    "Total number of HTTP requests",
+    registry=registry,
+)
+REQUEST_LATENCY = Summary(
+    "request_latency_seconds",
+    "Latency of HTTP requests in seconds",
+    registry=registry,
+)
+
+
+def prometheus_metrics() -> bytes:
+    """Return current metrics in Prometheus text format."""
+    return bytes(generate_latest(registry))

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -6,12 +6,15 @@ from datetime import datetime
 from typing import List
 
 from fastapi import FastAPI
+
+from backend.common.tracing import init_fastapi_tracing
 from pydantic import BaseModel
 
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
 
 app = FastAPI(title="Optimization Service")
+init_fastapi_tracing(app, "optimization")
 store = MetricsStore()
 
 

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -6,6 +6,8 @@ import json
 import os
 
 from flask import Flask, jsonify, request
+
+from backend.common.tracing import init_flask_tracing
 import redis
 
 from datetime import datetime
@@ -14,6 +16,7 @@ from .scoring import Signal, calculate_score
 from .weight_repository import get_weights, update_weights
 
 app = Flask(__name__)
+init_flask_tracing(app, "scoring-engine")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 redis_client = redis.Redis.from_url(REDIS_URL)
 

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -8,12 +8,15 @@ from typing import Callable, Coroutine
 
 from fastapi import FastAPI, Request, Response
 
+from backend.common.tracing import init_fastapi_tracing
+
 from .logging_config import configure_logging
 from .settings import settings
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
+init_fastapi_tracing(app, settings.app_name)
 
 
 @app.middleware("http")

--- a/docs/scoring_engine/conf.py
+++ b/docs/scoring_engine/conf.py
@@ -1,4 +1,4 @@
-# Configuration file for the Sphinx documentation builder.
+"""Sphinx configuration for the scoring engine docs."""
 
 import os
 import sys

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,5 @@
+"""Minimal Sphinx configuration for project documentation."""
+
 import os
 import sys
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -9,3 +9,9 @@ Modules
 
 .. automodule:: backend.optimization.api
     :members:
+
+.. automodule:: backend.monitoring.main
+    :members:
+
+.. automodule:: backend.common.tracing
+    :members:

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,3 +1,5 @@
+"""Sphinx configuration for internal mockup generation docs."""
+
 project = "mockup_generation"
 extensions = ["sphinx.ext.autodoc"]
 exclude_patterns = ["_build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,6 @@ docstring-convention = "google"
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true
-extend-ignore = []
-show-source = true
-
-[tool.mypy]
-python_version = "3.11"
 check_untyped_defs = true
 disallow_untyped_defs = true
 disallow_any_generics = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,9 @@ pytest
 pytest-cov
 requests
 httpx
+prometheus-client
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-flask
+opentelemetry-instrumentation-celery

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,28 @@
+"""Tests for the monitoring service."""
+
+from fastapi.testclient import TestClient
+
+from backend.monitoring.main import app
+
+client = TestClient(app)
+
+
+def test_metrics_endpoint() -> None:
+    """Ensure the metrics endpoint returns Prometheus data."""
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "python_info" in response.text
+
+
+def test_overview_endpoint() -> None:
+    """Verify the overview endpoint returns system status."""
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert response.json()["status"] == "operational"
+
+
+def test_logs_endpoint() -> None:
+    """Check logs endpoint returns text even if log file missing."""
+    response = client.get("/logs")
+    assert response.status_code == 200
+    assert "logs" in response.json()


### PR DESCRIPTION
## Summary
- create backend monitoring service exposing Prometheus metrics, system overview, analytics dashboard and logs
- add OpenTelemetry tracing helpers and instrument all backend services
- document new modules and include them in Sphinx build
- add tests for the monitoring service
- add Prometheus and OpenTelemetry dependencies

## Testing
- `flake8 backend/common/tracing.py backend/monitoring/metrics.py backend/monitoring/main.py backend/api-gateway/src/api_gateway/main.py backend/optimization/api.py backend/service-template/src/main.py backend/scoring-engine/scoring_engine/app.py backend/mockup-generation/mockup_generation/celery_app.py tests/test_monitoring.py`
- `mypy backend/common/tracing.py backend/monitoring/metrics.py backend/monitoring/main.py tests/test_monitoring.py`
- `pytest tests -q`
- `sphinx-build -b html docs docs/_build`

------
https://chatgpt.com/codex/tasks/task_b_6877c6c3a04883318a37851841f38c4c