### PR TITLE
Add CI workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker Build and Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build mockup-generation image
+        uses: docker/build-push-action@v5
+        with:
+          context: backend/mockup-generation
+          tags: mockup-generation:latest
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.22.0
+        with:
+          image-ref: mockup-generation:latest
+          severity: CRITICAL,HIGH
+          exit-code: 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,17 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install sphinx docformatter flake8 flake8-docstrings myst-parser sphinxcontrib-mermaid
       - name: Build documentation
         run: |
-          sphinx-build -b html -W docs docs/_build/html
+          sphinx-build -b html -W -n docs docs/_build/html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          npm ci
+      - name: Lint Python
+        run: |
+          flake8 .
+          mypy .
+      - name: Lint JavaScript and CSS
+        run: |
+          npm run lint
+          npm run flow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          npm ci
+          python -m pip install -e .
+      - name: Run tests
+        run: |
+          pytest -W error -vv


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting with flake8, mypy, eslint and stylelint
- add tests workflow running pytest with warnings treated as errors
- build Docker image and run Trivy vulnerability scan
- cache dependencies in docs workflow and fail on warnings

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_b_6877caef74b483319ff4182440fab367