### PR TITLE
Add Dagster orchestration job

### DIFF
--- a/backend/orchestrator/orchestrator/__init__.py
+++ b/backend/orchestrator/orchestrator/__init__.py
@@ -1,0 +1,5 @@
+"""Orchestration pipelines using Dagster."""
+
+from .jobs import idea_job
+
+__all__ = ["idea_job"]

--- a/backend/orchestrator/orchestrator/jobs.py
+++ b/backend/orchestrator/orchestrator/jobs.py
@@ -1,0 +1,23 @@
+"""Dagster jobs composing the orchestration pipeline."""
+
+from __future__ import annotations
+
+from dagster import job
+
+from .ops import (
+    await_approval,
+    generate_content,
+    ingest_signals,
+    publish_content,
+    score_signals,
+)
+
+
+@job
+def idea_job() -> None:
+    """Pipeline from ingestion to publishing."""
+    signals = ingest_signals()
+    scores = score_signals(signals)
+    items = generate_content(scores)
+    await_approval()
+    publish_content(items)

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -1,0 +1,48 @@
+"""Dagster operations for the orchestration pipeline."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from dagster import Failure, RetryPolicy, op
+
+
+@op
+def ingest_signals(context) -> List[str]:
+    """Fetch new signals."""
+    context.log.info("ingesting signals")
+    # Placeholder for actual ingestion logic
+    return ["signal-1"]
+
+
+@op
+def score_signals(context, signals: List[str]) -> List[float]:
+    """Score the ingested signals."""
+    context.log.info("scoring %d signals", len(signals))
+    # Placeholder for actual scoring logic
+    return [1.0 for _ in signals]
+
+
+@op
+def generate_content(context, scores: List[float]) -> List[str]:
+    """Generate content based on scores."""
+    context.log.info("generating %d items", len(scores))
+    # Placeholder for actual generation logic
+    return [f"item-{i}" for i, _ in enumerate(scores)]
+
+
+@op
+def await_approval() -> None:
+    """Fail if publishing has not been approved."""
+    if os.environ.get("APPROVE_PUBLISHING") != "true":
+        raise Failure("publishing not approved")
+
+
+@op(retry_policy=RetryPolicy(max_retries=3, delay=1))
+def publish_content(context, items: List[str]) -> None:
+    """Publish generated content."""
+    context.log.info("publishing %d items", len(items))
+    # Placeholder for actual publish logic
+    for item in items:
+        context.log.debug("published %s", item)

--- a/backend/orchestrator/tests/test_jobs.py
+++ b/backend/orchestrator/tests/test_jobs.py
@@ -1,0 +1,15 @@
+"""Tests for the Dagster orchestrator."""
+
+from orchestrator.jobs import idea_job
+
+
+def test_job_structure() -> None:
+    """Verify job includes all steps in order."""
+    ops = [op.name for op in idea_job.graph.node_dict.values()]
+    assert ops == [
+        "ingest_signals",
+        "score_signals",
+        "generate_content",
+        "await_approval",
+        "publish_content",
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 requests
 httpx
 requests-mock
+dagster


### PR DESCRIPTION
## Summary
- orchestrate ingestion → scoring → generation → publishing steps using Dagster
- require manual approval before publishing and retry failures
- test pipeline structure
- add Dagster to requirements

## Testing
- `npm ci --legacy-peer-deps`
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `python -m pip install sphinx myst-parser sphinxcontrib-mermaid` *(failed: ExtensionError during doc build)*
- `PYTHONPATH=. pytest backend/orchestrator/tests/test_jobs.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6877cafe4ce883319d52f9febf625a76