### PR TITLE
Fix integration test dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,10 @@ mypy
 pydocstyle
 flake8-docstrings
 docformatter
+vcrpy
+Pillow
+redis
+asyncpg
+scikit-learn
+pytest-asyncio
+aiosqlite


### PR DESCRIPTION
## Summary
- add missing libraries to `requirements-dev.txt` so that integration tests run

## Testing
- `./scripts/run-integration-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_6877dcdb3a5083319297c1948b230420