### PR TITLE
Add release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,19 @@ To get started:
    ```
 
 The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Warnings are treated as errors, so commits will fail until issues are fixed.
+
+## Commit Messages
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Examples:
+
+```
+feat: add scoring endpoint
+fix: correct error handling
+chore: update dependencies
+```
+
+Use these prefixes so the release script can determine the next semantic version and generate the changelog.
+
+## Releasing
+
+Run `./scripts/release.sh <registry>` after your changes are merged. The script updates `CHANGELOG.md`, creates a git tag, builds Docker images and pushes them with the new version number.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 
 Run `scripts/register_schemas.py` after the Kafka and schema registry containers
 start to register the provided JSON schemas.
+
+## Release process
+
+1. Ensure all commits follow the Conventional Commits specification.
+2. Run `./scripts/release.sh <registry>` to generate the changelog, tag the release and publish versioned Docker images.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Create a semver tag, update CHANGELOG and push Docker images.
+# Usage: ./scripts/release.sh <docker_registry>
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+LAST_VERSION=${LAST_TAG#v}
+COMMITS=$(git log "$LAST_TAG"..HEAD --pretty=format:%s)
+BUMP="patch"
+for msg in $COMMITS; do
+    if [[ "$msg" == *"BREAKING CHANGE"* || "$msg" == *"!:"* ]]; then
+        BUMP="major"
+        break
+    elif [[ "$msg" == feat* && "$BUMP" != major ]]; then
+        BUMP="minor"
+    elif [[ "$msg" == fix* && "$BUMP" == patch ]]; then
+        BUMP="patch"
+    fi
+done
+IFS=. read -r major minor patch <<<"$LAST_VERSION"
+case "$BUMP" in
+    major)
+        major=$((major+1)); minor=0; patch=0;;
+    minor)
+        minor=$((minor+1)); patch=0;;
+    patch)
+        patch=$((patch+1));;
+esac
+NEW_VERSION="$major.$minor.$patch"
+DATE=$(date +"%Y-%m-%d")
+CHANGELOG_ENTRY="## v$NEW_VERSION - $DATE"$'\n'
+CHANGELOG_ENTRY+="$(git log "$LAST_TAG"..HEAD --pretty=format:"- %s (%h)")"$'\n\n'
+{ printf "%s" "$CHANGELOG_ENTRY"; cat CHANGELOG.md 2>/dev/null; } > CHANGELOG.tmp
+mv CHANGELOG.tmp CHANGELOG.md
+git add CHANGELOG.md
+git commit -m "chore(release): v$NEW_VERSION" || true
+git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+./scripts/build-images.sh
+if [[ $# -gt 0 ]]; then
+    ./scripts/push-images.sh "$1" "v$NEW_VERSION"
+fi


### PR DESCRIPTION
## Summary
- document Conventional Commits in CONTRIBUTING
- add release process notes in README
- create `scripts/release.sh` for changelog generation and tagging
- initialize `CHANGELOG.md`

## Testing
- `pip install pre-commit` *(passed)*
- `npm ci` *(failed: ERESOLVE could not resolve)*
- `pre-commit run --files scripts/release.sh CONTRIBUTING.md README.md CHANGELOG.md` *(failed: asked for GitHub credentials)*
- `pytest -q` *(failed: terminated)*

------
https://chatgpt.com/codex/tasks/task_b_6877e070cce08331a8febdf49070cbc1