### PR TITLE
Add docstrings and enforce doc checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           flake8 .
           mypy .
+          pydocstyle .
+          docformatter --check --recursive .
       - name: Lint JavaScript and CSS
         run: |
           npm run lint

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -25,7 +25,10 @@ class GenerationResult:
 class MockupGenerator:
     """Generate mockups using Stable Diffusion XL with fallback."""
 
-    def __init__(self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0") -> None:
+    def __init__(
+        self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0"
+    ) -> None:
+        """Initialize the generator with the model identifier."""
         self.model_id = model_id
         self.pipeline: Optional[StableDiffusionXLPipeline] = None
 
@@ -33,17 +36,23 @@ class MockupGenerator:
         """Load the diffusion pipeline on GPU if available."""
         if self.pipeline is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(device)
+            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(
+                device
+            )
             self.pipeline.enable_attention_slicing()
 
-    def generate(self, prompt: str, output_path: str, *, num_inference_steps: int = 30) -> GenerationResult:
+    def generate(
+        self, prompt: str, output_path: str, *, num_inference_steps: int = 30
+    ) -> GenerationResult:
         """Generate an image or fall back to external API on failure."""
         from time import perf_counter
 
         self.load()
         start = perf_counter()
         try:
-            image = self.pipeline(prompt=prompt, num_inference_steps=num_inference_steps).images[0]
+            image = self.pipeline(
+                prompt=prompt, num_inference_steps=num_inference_steps
+            ).images[0]
         except Exception as exc:  # pylint: disable=broad-except
             logger.warning("Local generation failed: %s. Falling back to API", exc)
             image = self._fallback_api(prompt)

--- a/backend/orchestrator/tests/__init__.py
+++ b/backend/orchestrator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the orchestrator service."""

--- a/backend/scoring-engine/scoring_engine/weight_repository.py
+++ b/backend/scoring-engine/scoring_engine/weight_repository.py
@@ -26,6 +26,7 @@ class WeightParams:
 
 
 def _to_params(model: Weights) -> WeightParams:
+    """Convert a ``Weights`` ORM object to ``WeightParams`` dataclass."""
     return WeightParams(
         freshness=model.freshness,
         engagement=model.engagement,

--- a/backend/shared/kafka/schema_registry.py
+++ b/backend/shared/kafka/schema_registry.py
@@ -12,6 +12,7 @@ class SchemaRegistryClient:
     """Simple client for interacting with a schema registry."""
 
     def __init__(self, url: str) -> None:
+        """Initialize the client with the registry ``url``."""
         self._url = url.rstrip("/")
 
     def register(self, subject: str, schema: Dict[str, Any]) -> None:

--- a/backend/shared/kafka/utils.py
+++ b/backend/shared/kafka/utils.py
@@ -15,6 +15,7 @@ class KafkaProducerWrapper:
     """Kafka producer that validates messages against schemas."""
 
     def __init__(self, bootstrap_servers: str, registry: SchemaRegistryClient) -> None:
+        """Create producer connected to ``bootstrap_servers`` using ``registry``."""
         self._producer = KafkaProducer(
             bootstrap_servers=bootstrap_servers,
             value_serializer=lambda v: json.dumps(v).encode(),
@@ -38,6 +39,7 @@ class KafkaConsumerWrapper:
         registry: SchemaRegistryClient,
         topics: Iterable[str],
     ) -> None:
+        """Initialize consumer subscribed to ``topics``."""
         self._consumer = KafkaConsumer(
             *topics,
             bootstrap_servers=bootstrap_servers,


### PR DESCRIPTION
## Summary
- add constructor docstrings to generator and Kafka helpers
- document weight repository helper function
- document orchestrator tests package
- enforce docstring style in lint workflow

## Testing
- `docformatter --check --recursive backend/mockup-generation/mockup_generation/generator.py backend/shared/kafka/schema_registry.py backend/shared/kafka/utils.py backend/scoring-engine/scoring_engine/weight_repository.py backend/orchestrator/tests/__init__.py`
- `flake8 backend/mockup-generation/mockup_generation/generator.py backend/shared/kafka/schema_registry.py backend/shared/kafka/utils.py backend/scoring-engine/scoring_engine/weight_repository.py backend/orchestrator/tests/__init__.py`
- `pydocstyle backend/mockup-generation/mockup_generation/generator.py backend/shared/kafka/schema_registry.py backend/shared/kafka/utils.py backend/scoring-engine/scoring_engine/weight_repository.py backend/orchestrator/tests/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api_gateway')*

------
https://chatgpt.com/codex/tasks/task_b_6877e0b463a883319b60b7fea01eb88c