### PR TITLE
Add quickstart, cloud deployment, and troubleshooting docs

### DIFF
--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -1,0 +1,43 @@
+# Cloud Deployment Guides
+
+This document outlines how to deploy desAInz to AWS, Google Cloud Platform and Microsoft Azure using container images.
+
+## AWS
+
+1. **Build and push images** to Amazon Elastic Container Registry (ECR).
+   ```bash
+   aws ecr create-repository --repository-name desainz
+   docker build -t desainz .
+   docker tag desainz:latest <account>.dkr.ecr.<region>.amazonaws.com/desainz:latest
+   docker push <account>.dkr.ecr.<region>.amazonaws.com/desainz:latest
+   ```
+2. **Provision a cluster** using ECS or EKS.
+3. **Create task definitions or Kubernetes manifests** pointing to the pushed image.
+4. **Expose services** with an Application Load Balancer and configure TLS.
+
+## GCP
+
+1. **Upload images** to Google Artifact Registry.
+   ```bash
+   gcloud artifacts repositories create desainz --repository-format=docker --location=<region>
+   docker build -t gcr.io/<project>/desainz .
+   docker push gcr.io/<project>/desainz
+   ```
+2. **Deploy** to Cloud Run or GKE using the uploaded image.
+3. **Configure networking and TLS** via Cloud Load Balancing.
+
+## Azure
+
+1. **Push images** to Azure Container Registry (ACR).
+   ```bash
+   az acr create --name desainz --resource-group <rg> --sku Basic
+   docker build -t desainz .
+   az acr login --name desainz
+   docker tag desainz:latest desainz.azurecr.io/desainz:latest
+   docker push desainz.azurecr.io/desainz:latest
+   ```
+2. **Run containers** using Azure Container Instances or AKS.
+3. **Create an ingress controller** if using AKS and configure TLS.
+
+These high-level steps give an overview of deploying the application on each cloud platform. Refer to the provider documentation for production hardening guidance.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,9 @@ Welcome to desAInz's documentation!
    :caption: Contents:
 
    README
+   quickstart
+   cloud_deployment
+   troubleshooting
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,48 @@
+# Local Quick Start
+
+Follow these steps to run desAInz on your workstation.
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/your-org/desAInz.git
+cd desAInz
+```
+
+## 2. Install dependencies
+
+Use the provided setup script to install Python and Node packages and build the documentation.
+
+```bash
+./scripts/setup_codex.sh
+```
+
+## 3. Launch the stack
+
+Start the application and its services with Docker Compose.
+
+```bash
+docker-compose up -d
+```
+
+Once all containers are healthy, register the Kafka schemas.
+
+```bash
+python scripts/register_schemas.py
+```
+
+## 4. Verify the application
+
+Check that the API and frontend respond.
+
+```bash
+curl http://localhost:8000/health
+curl http://localhost:3000
+```
+
+You can stop the stack with:
+
+```bash
+docker-compose down
+```
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,32 @@
+# Troubleshooting FAQ
+
+## Docker containers fail to start
+
+Ensure the required ports (5432, 6379, 9092, 9000, 3000 and 8000) are free. Remove any old containers with:
+
+```bash
+docker-compose down -v
+```
+
+and try again.
+
+## Documentation build errors
+
+The Sphinx configuration treats warnings as errors. Run the setup script to install required packages and rebuild:
+
+```bash
+./scripts/setup_codex.sh
+```
+
+## Schemas are not registered
+
+The API relies on Kafka schemas being present. Run:
+
+```bash
+python scripts/register_schemas.py
+```
+
+## Application ports are unreachable
+
+Check that your firewall allows connections to the exposed ports and verify the containers are listening with `docker ps`.
+


### PR DESCRIPTION
## Summary
- document local quick start steps
- add cloud deployment guide for AWS, GCP and Azure
- add troubleshooting FAQ
- include the new docs in the Sphinx index

## Testing
- `docformatter --in-place --recursive docs`
- `flake8 --select=D docs`
- `black --check .` *(fails: would reformat)*
- `flake8`
- `mypy .` *(fails: duplicate module named tests)*
- `npm ci` *(fails: dependency conflict)*
- `pytest -q` *(fails: ModuleNotFoundError during collection)*
- `sphinx-build -W -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_b_6877e081f6588331a919017058106204