### PR TITLE
Add pydocstyle to CI and update commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           flake8 .
           mypy .
+          pydocstyle
       - name: Lint JavaScript and CSS
         run: |
           npm run lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-        args: ["--check"]
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
@@ -38,7 +37,7 @@ repos:
         language: node
         files: \.(js|jsx|ts|tsx|css|scss|md)$
         additional_dependencies: ["prettier"]
-        args: ["--check"]
+        args: ["--write"]
       - id: flow
         name: flow
         entry: flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,7 @@ To get started:
    pre-commit install
    ```
 
+Black and Prettier run in formatting mode, so staged files will be automatically
+updated.
+
 The hooks enforce Black, flake8, mypy, docformatter, pydocstyle, eslint, prettier, flow and stylelint. Warnings are treated as errors, so commits will fail until issues are fixed.


### PR DESCRIPTION
## Summary
- run `pydocstyle` as part of lint workflow
- auto-format with Black and Prettier in pre-commit hooks
- document the automatic formatting in CONTRIBUTING

## Testing
- `./scripts/setup_codex.sh` *(failed: npm dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0799df08331b9b0c5f52ba18291