### PR TITLE
Add secret management docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 
 Run `scripts/register_schemas.py` after the Kafka and schema registry containers
 start to register the provided JSON schemas.
+
+## Configuration and Secrets
+
+Local development uses dotenv files. Copy the `.env.example` in each service to `.env` and adjust the values for your environment. The services automatically load these variables using Pydantic `BaseSettings`.
+
+In production, secrets are stored in HashiCorp Vault or AWS Secrets Manager and injected into the running services by the deployment manifests. Do not rely on `.env` files in production.
+
+See [docs/security.md](docs/security.md) for the rotation procedure.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   security
 
 
 Kafka Utilities

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,23 @@
+# Security and Secret Management
+
+This project relies on environment variables for configuration.
+
+## Local development
+
+- Copy `.env.example` files to `.env` inside each service directory.
+- Adjust the values for your local setup.
+- The applications load these variables automatically via `pydantic.BaseSettings`.
+
+## Production
+
+- Secrets are stored in HashiCorp Vault or AWS Secrets Manager.
+- Deployment manifests fetch the secrets at runtime.
+- `.env` files are **not** used in production.
+
+## Secret rotation procedure
+
+1. Create a new version of the secret in the secret manager.
+2. Update the deployment configuration to reference the new version.
+3. Deploy to a staging environment and verify the rollout.
+4. Promote the secret to production after validation.
+5. Remove the previous version when all services consume the new secret.


### PR DESCRIPTION
## Summary
- document how to use `.env` files in development and secret stores in production
- add security and rotation guidelines
- link new page in documentation index

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_6877e07321ec8331be470198f2b267c9