### PR TITLE
Add frontend i18n setup

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,16 @@
+# Internationalization Workflow
+
+This project uses `i18next` with `react-i18next` for client side translations in the admin dashboard. All text visible to users should be referenced through the `t()` helper so strings can be translated.
+
+## Adding or updating translations
+
+1. Edit the locale files under `frontend/admin-dashboard/src/locales`. Each language has its own folder with a `common.json` file.
+2. After modifying translation files, commit the changes.
+3. Run `npm run lint` in `frontend/admin-dashboard` to ensure ESLint passes.
+4. Tests can be run with `npm test` and `pytest` from the repository root.
+
+## Creating new strings
+
+Wrap any new user-facing text with the `t()` hook from `react-i18next` and add the key/value pair to the locale files.
+
+This keeps translations in one place and makes it easy to add more languages in the future.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   i18n
 
 
 Kafka Utilities

--- a/frontend/admin-dashboard/app/page.tsx
+++ b/frontend/admin-dashboard/app/page.tsx
@@ -1,7 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function Home() {
+  const { t } = useTranslation();
   return (
     <main>
-      <h1>Admin Dashboard</h1>
+      <h1>{t('title')}</h1>
     </main>
   );
 }

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -11,9 +11,12 @@
   },
   "dependencies": {
     "@shadcn/ui": "^0.0.4",
+    "@types/react-i18next": "^7.8.3",
+    "i18next": "^25.3.2",
     "next": "15.4.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-i18next": "^15.6.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",

--- a/frontend/admin-dashboard/src/i18n.ts
+++ b/frontend/admin-dashboard/src/i18n.ts
@@ -1,0 +1,17 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import enCommon from './locales/en/common.json';
+
+void i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: enCommon },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -1,27 +1,33 @@
 import React from 'react';
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { t } = useTranslation();
   return (
     <div className="flex h-screen">
       <aside className="w-64 bg-gray-800 text-white p-4">
         <nav className="space-y-2">
           <Link href="/dashboard" className="block hover:underline">
-            Dashboard
+            {t('dashboard')}
           </Link>
           <Link href="/dashboard/heatmap" className="block hover:underline">
-            Heatmap
+            {t('heatmap')}
           </Link>
           <Link href="/dashboard/gallery" className="block hover:underline">
-            Gallery
+            {t('gallery')}
           </Link>
           <Link href="/dashboard/ab-tests" className="block hover:underline">
-            AB Tests
+            {t('abTests')}
           </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">
-        <header className="bg-gray-100 p-4 shadow">Admin Dashboard</header>
+        <header className="bg-gray-100 p-4 shadow">{t('title')}</header>
         <main className="p-4 flex-1 overflow-auto">{children}</main>
       </div>
     </div>

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -1,0 +1,11 @@
+{
+  "title": "Admin Dashboard",
+  "dashboard": "Dashboard",
+  "heatmap": "Heatmap",
+  "gallery": "Gallery",
+  "abTests": "AB Tests",
+  "signalStreamComingSoon": "Signal stream coming soon.",
+  "galleryPlaceholder": "Gallery page placeholder.",
+  "heatmapPlaceholder": "Heatmap page placeholder.",
+  "abTestsPlaceholder": "AB Tests page placeholder."
+}

--- a/frontend/admin-dashboard/src/pages/_app.tsx
+++ b/frontend/admin-dashboard/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import AdminLayout from '../layouts/AdminLayout';
+import '../i18n';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function AbTestsPage() {
-  return <div>AB Tests page placeholder.</div>;
+  const { t } = useTranslation();
+  return <div>{t('abTestsPlaceholder')}</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function GalleryPage() {
-  return <div>Gallery page placeholder.</div>;
+  const { t } = useTranslation();
+  return <div>{t('galleryPlaceholder')}</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function HeatmapPage() {
-  return <div>Heatmap page placeholder.</div>;
+  const { t } = useTranslation();
+  return <div>{t('heatmapPlaceholder')}</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/index.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function DashboardPage() {
-  return <div>Signal stream coming soon.</div>;
+  const { t } = useTranslation();
+  return <div>{t('signalStreamComingSoon')}</div>;
 }


### PR DESCRIPTION
## Summary
- integrate i18next/react-i18next into the admin dashboard
- translate all existing UI strings
- document the translation workflow

## Testing
- `npm run lint`
- `npm test`
- `flake8 docs/i18n.md`
- `pydocstyle docs/i18n.md`
- `docformatter -i docs/i18n.md`
- `sphinx-build -b html docs docs/_build`
- `pytest -q` *(fails: ModuleNotFoundError: monitoring)*

------
https://chatgpt.com/codex/tasks/task_b_6877e067d2dc833197eb458439c49695