### PR TITLE
Improve accessibility with WCAG checks

### DIFF
--- a/frontend/admin-dashboard/__tests__/layout.test.tsx
+++ b/frontend/admin-dashboard/__tests__/layout.test.tsx
@@ -1,15 +1,17 @@
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import RootLayout from '../app/layout';
 
-test('renders children inside layout', () => {
+test('renders children inside layout', async () => {
   const originalError = console.error;
   console.error = jest.fn();
-  render(
+  const { container } = render(
     <RootLayout>
       <div>Child</div>
-    </RootLayout>,
-    { container: document.documentElement }
+    </RootLayout>
   );
   expect(screen.getByText('Child')).toBeInTheDocument();
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
   console.error = originalError;
 });

--- a/frontend/admin-dashboard/app/layout.tsx
+++ b/frontend/admin-dashboard/app/layout.tsx
@@ -7,14 +7,15 @@ export const metadata: Metadata = {
   description: 'Admin dashboard application',
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <a href="#root-main" className="skip-link">
+          Skip to main content
+        </a>
+        <main id="root-main">{children}</main>
+      </body>
     </html>
   );
 }

--- a/frontend/admin-dashboard/jest.setup.ts
+++ b/frontend/admin-dashboard/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'jest-axe/extend-expect';

--- a/frontend/admin-dashboard/package-lock.json
+++ b/frontend/admin-dashboard/package-lock.json
@@ -28,10 +28,12 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.21",
+        "axe-core": "^4.10.3",
         "babel-jest": "^30.0.4",
         "eslint": "^9",
         "eslint-config-next": "15.4.1",
         "jest": "^30.0.4",
+        "jest-axe": "^10.0.0",
         "jest-environment-jsdom": "^30.0.4",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
@@ -6278,6 +6280,16 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -8585,6 +8597,119 @@
         }
       }
     },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-axe/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-changed-files": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.0.2.tgz",
@@ -8901,6 +9026,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -35,10 +35,12 @@
     "eslint-config-next": "15.4.1",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
+    "jest-axe": "^10.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "axe-core": "^4.10.3"
   }
 }

--- a/frontend/admin-dashboard/src/components/Button.tsx
+++ b/frontend/admin-dashboard/src/components/Button.tsx
@@ -5,6 +5,7 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 export function Button({ children, className = '', ...props }: ButtonProps) {
   return (
     <button
+      type="button"
       className={`inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-white ${className}`}
       {...props}
     >

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import Link from 'next/link';
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex h-screen">
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <aside className="w-64 bg-gray-800 text-white p-4">
-        <nav className="space-y-2">
+        <nav className="space-y-2" role="navigation" aria-label="Main">
           <Link href="/dashboard" className="block hover:underline">
             Dashboard
           </Link>
@@ -21,8 +28,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
         </nav>
       </aside>
       <div className="flex flex-col flex-1">
-        <header className="bg-gray-100 p-4 shadow">Admin Dashboard</header>
-        <main className="p-4 flex-1 overflow-auto">{children}</main>
+        <header className="bg-gray-100 p-4 shadow" aria-label="Page header">
+          Admin Dashboard
+        </header>
+        <main id="main-content" className="p-4 flex-1 overflow-auto">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/frontend/admin-dashboard/src/styles/globals.css
+++ b/frontend/admin-dashboard/src/styles/globals.css
@@ -1,3 +1,22 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.skip-link {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  padding: 0.5rem 1rem;
+  background: white;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add skip links and ARIA labels to admin dashboard layout
- add default button type
- update root layout with skip link
- style skip links
- add axe-core accessibility test
- include jest-axe and axe-core in admin dashboard deps

## Testing
- `npm run lint` within `frontend/admin-dashboard`
- `npm test` within `frontend/admin-dashboard`
- `flake8`
- `mypy backend`
- `black --check .`
- `pydocstyle`
- `docformatter -c .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6877e067712c833190d91bc7264c0ccb