### PR TITLE
Enhance docs generation

### DIFF
--- a/docs/api/backend.optimization.rst
+++ b/docs/api/backend.optimization.rst
@@ -1,0 +1,34 @@
+backend.optimization package
+============================
+
+.. automodule:: backend.optimization
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.optimization.api module
+-------------------------------
+
+.. automodule:: backend.optimization.api
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.optimization.metrics module
+-----------------------------------
+
+.. automodule:: backend.optimization.metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.optimization.storage module
+-----------------------------------
+
+.. automodule:: backend.optimization.storage
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.rst
+++ b/docs/api/backend.rst
@@ -1,0 +1,15 @@
+backend package
+===============
+
+.. automodule:: backend
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   backend.optimization

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+backend
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   backend

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,17 @@
+Architecture
+============
+
+.. mermaid::
+
+   graph TB
+       users[Users] --> dashboard[Admin Dashboard]
+       dashboard --> api[API Gateway]
+       api --> template[Service Template]
+       api --> mockup[Mockup Generation]
+       api --> scoring[Scoring Engine]
+       template --> storage[S3 Storage]
+       mockup --> storage
+       scoring --> storage
+
+This diagram shows the high-level interaction between the dashboard and the
+backend services.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,8 +28,11 @@ extensions = [
     "myst_parser",
     "sphinxcontrib.mermaid",
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
 ]
+
+autosummary_generate = True
 
 autodoc_mock_imports = [
     "flask",
@@ -41,6 +44,11 @@ autodoc_mock_imports = [
     "sqlalchemy",
     "psycopg2",
     "selenium",
+    "apscheduler",
+    "scoring_engine",
+    "backend.optimization",
+    "marketplace_publisher",
+    "monitoring",
 ]
 
 source_suffix = {
@@ -49,10 +57,7 @@ source_suffix = {
 }
 
 templates_path = ["_templates"]
-exclude_patterns: list[str] = [
-    "scoring_engine/*",
-    "source/*",
-]
+exclude_patterns: list[str] = []
 
 # Treat warnings as errors
 nitpicky = True
@@ -81,6 +86,23 @@ def _run_linters(app: "Sphinx") -> None:
     subprocess.check_call(["flake8", "--select=D", docs_dir])
 
 
+def _run_apidoc(app: "Sphinx") -> None:
+    """Generate API docs for all Python modules."""
+    output_path = os.path.join(app.srcdir, "api")
+    module_path = os.path.abspath(os.path.join(app.srcdir, "..", "backend"))
+    subprocess.check_call(
+        [
+            "sphinx-apidoc",
+            "--force",
+            "--module-first",
+            "--output-dir",
+            output_path,
+            module_path,
+        ]
+    )
+
+
 def setup(app: "Sphinx") -> None:
     """Set up Sphinx hooks."""
     app.connect("builder-inited", _run_linters)
+    app.connect("builder-inited", _run_apidoc)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,10 @@ Welcome to desAInz's documentation!
    :caption: Contents:
 
    README
+   architecture
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   api/modules
 
 
 Kafka Utilities


### PR DESCRIPTION
## Summary
- autogenerate API docs for the `backend` modules
- add simple architecture diagram page
- publish docs without autoapi dependency
- update setup script to install minimal doc dependencies

## Testing
- `scripts/setup_codex.sh` *(fails: ERESOLVE could not resolve)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api_gateway')*
- `sphinx-build -b html -W docs docs/_build/html` *(fails with warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_b_6877e07c657c8331a4514e75c4191291