### PR TITLE
Add PgBouncer and index migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 
 Run `scripts/register_schemas.py` after the Kafka and schema registry containers
 start to register the provided JSON schemas.
+
+PgBouncer connection pooling is available via the `pgbouncer` service in
+`docker-compose.yml`. Point `DATABASE_URL` at port `6432` to leverage pooling.
+Execute `scripts/analyze_query_plans.py` periodically to inspect query plans and
+identify missing indexes.

--- a/backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py
@@ -1,0 +1,34 @@
+"""Add indexes for frequent lookups."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create indexes to optimize common queries."""
+    op.create_index(op.f("ix_signals_idea_id"), "signals", ["idea_id"], unique=False)
+    op.create_index(
+        op.f("ix_signals_timestamp"), "signals", ["timestamp"], unique=False
+    )
+    op.create_index(op.f("ix_mockups_idea_id"), "mockups", ["idea_id"], unique=False)
+    op.create_index(
+        op.f("ix_listings_mockup_id"), "listings", ["mockup_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_ab_tests_listing_id"), "ab_tests", ["listing_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop added indexes."""
+    op.drop_index(op.f("ix_ab_tests_listing_id"), table_name="ab_tests")
+    op.drop_index(op.f("ix_listings_mockup_id"), table_name="listings")
+    op.drop_index(op.f("ix_mockups_idea_id"), table_name="mockups")
+    op.drop_index(op.f("ix_signals_timestamp"), table_name="signals")
+    op.drop_index(op.f("ix_signals_idea_id"), table_name="signals")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,13 @@ services:
       interval: 10s
       retries: 5
 
+  pgbouncer:
+    build: ./docker/pgbouncer
+    ports:
+      - "6432:6432"
+    depends_on:
+      - postgres
+
   redis:
     build: ./docker/redis
     ports:

--- a/docker/pgbouncer/Dockerfile
+++ b/docker/pgbouncer/Dockerfile
@@ -1,0 +1,4 @@
+FROM pgbouncer/pgbouncer:latest
+COPY pgbouncer.ini /etc/pgbouncer/
+EXPOSE 6432
+HEALTHCHECK --interval=10s --retries=5 CMD pgbouncer --version

--- a/docker/pgbouncer/pgbouncer.ini
+++ b/docker/pgbouncer/pgbouncer.ini
@@ -1,0 +1,11 @@
+[databases]
+app = host=postgres port=5432 dbname=app user=user password=password
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = trust
+pool_mode = transaction
+max_client_conn = 100
+default_pool_size = 20
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-flask
 Flask
 pydantic-settings
+psycopg2-binary

--- a/scripts/analyze_query_plans.py
+++ b/scripts/analyze_query_plans.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Analyze query plans and suggest missing indexes."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import psycopg2
+from psycopg2.extras import DictCursor
+
+QUERIES = [
+    ("signals_by_idea", "SELECT * FROM signals WHERE idea_id = %s LIMIT 1", (1,)),
+    (
+        "mockups_by_idea",
+        "SELECT * FROM mockups WHERE idea_id = %s LIMIT 1",
+        (1,),
+    ),
+    (
+        "listings_by_mockup",
+        "SELECT * FROM listings WHERE mockup_id = %s LIMIT 1",
+        (1,),
+    ),
+]
+
+
+def main() -> None:
+    """Run EXPLAIN on common queries and print query plans."""
+    dsn = os.getenv(
+        "DATABASE_URL",
+        "postgresql://user:password@localhost:5432/app",
+    )
+    conn = psycopg2.connect(dsn)
+    try:
+        with conn.cursor(cursor_factory=DictCursor) as cur:
+            for name, query, params in QUERIES:
+                cur.execute("EXPLAIN " + query, params)
+                plan = "\n".join(row[0] for row in cur.fetchall())
+                logging.info("%s:\n%s", name, plan)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
## Summary
- add database indexes for frequent lookups
- provide PgBouncer container and integrate in docker-compose
- document PgBouncer usage and add query plan analyzer script
- require psycopg2-binary runtime dependency

## Testing
- `flake8 backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py scripts/analyze_query_plans.py`
- `black --check backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py scripts/analyze_query_plans.py`
- `mypy backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py scripts/analyze_query_plans.py`
- `pydocstyle backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py scripts/analyze_query_plans.py`
- `docformatter -c backend/shared/db/migrations/scoring_engine/versions/0002_add_common_indexes.py scripts/analyze_query_plans.py`
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: jest globals not defined)*
- `pytest -q` *(fails: missing modules)*
- `sphinx-build -W -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_b_6877e07f2030833191bff35d04f84d44