### PR TITLE
Add stylelint and Tailwind config

### DIFF
--- a/docs/admin_dashboard_trpc.md
+++ b/docs/admin_dashboard_trpc.md
@@ -7,3 +7,10 @@ When a user interacts with the dashboard, the frontend issues tRPC calls to the 
 All tRPC routes are declared in the `api-gateway` package. The dashboard imports the generated TypeScript types to guarantee that its calls match the server's expectations. Errors are propagated back through the gateway and surfaced in the dashboard's UI.
 
 For more details on implementing new routes, see the `api-gateway` documentation and the tRPC project guidelines.
+
+## Tailwind Configuration
+
+The dashboard uses a custom Tailwind setup defined in `tailwind.config.ts`. The theme
+extends the default palette with a `brand` color and sets the sans and mono font
+families from CSS variables. This ensures consistent colors and fonts across all
+components.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,4 +23,5 @@ Admin Dashboard
 ---------------
 The admin dashboard is a Next.js application found in ``frontend/admin-dashboard``.
 Any shared TypeScript interfaces located in this package are included in the
-documentation build.
+documentation build. The Tailwind configuration extends the default color
+palette and font families to maintain consistent styling.

--- a/frontend/admin-dashboard/tailwind.config.ts
+++ b/frontend/admin-dashboard/tailwind.config.ts
@@ -3,7 +3,19 @@ import type { Config } from 'tailwindcss';
 const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          light: '#f0fdf4',
+          DEFAULT: '#34d399',
+          dark: '#047857',
+        },
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', 'sans-serif'],
+        mono: ['var(--font-mono)', 'monospace'],
+      },
+    },
   },
   plugins: [],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint:eslint": "eslint . --ext .js,.jsx --max-warnings=0",
     "lint:prettier": "prettier \"**/*.{js,jsx,css,json,md}\" --check",
-    "lint:stylelint": "stylelint \"**/*.css\" --max-warnings=0 --allow-empty-input",
+    "lint:stylelint": "stylelint \"**/*.{css,scss}\" --max-warnings=0 --allow-empty-input",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:stylelint && npm run flow",
     "flow": "flow check --max-warnings=0",
     "test": "npm run lint"


### PR DESCRIPTION
## Summary
- enforce stylelint on CSS and SCSS files
- extend Tailwind theme with brand colors and fonts
- document Tailwind configuration

## Testing
- `npm ci --legacy-peer-deps`
- `pre-commit run --files package.json frontend/admin-dashboard/tailwind.config.ts docs/admin_dashboard_trpc.md docs/index.rst` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_b_6877e08745ac83318a81bc0d2104623b