### PR TITLE
Automate backups and document restore steps

### DIFF
--- a/docker/backup/Dockerfile
+++ b/docker/backup/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y postgresql-client awscli && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY scripts/backup.py /app/backup.py
+ENTRYPOINT ["python", "/app/backup.py"]

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,33 @@
+# Backup and Restore
+
+This document describes how backups are created and how to restore the
+system in the event of data loss.
+
+## Scheduled Backups
+
+Backups run nightly using a Kubernetes CronJob defined in the `backup-jobs`
+Helm chart. The job executes `scripts/backup.py` inside a small container
+with `pg_dump` and the AWS CLI installed.
+
+The script performs two tasks:
+
+1. Dumps the PostgreSQL database to a temporary file and uploads it to the
+   S3 bucket specified by `BACKUP_BUCKET`.
+2. Synchronizes the MinIO data directory to the same bucket using
+   `aws s3 sync`.
+
+## Restoring from Backup
+
+1. Download the desired SQL dump from your backup bucket:
+   ```bash
+   aws s3 cp s3://<bucket>/postgres/postgres_<timestamp>.sql ./restore.sql
+   ```
+2. Restore the database:
+   ```bash
+   psql -h <db-host> -U <user> -d <db-name> -f restore.sql
+   ```
+3. Retrieve the MinIO archive:
+   ```bash
+   aws s3 sync s3://<bucket>/minio/ /path/to/minio/data
+   ```
+4. Restart the MinIO service so it picks up the restored objects.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   backup
 
 
 Kafka Utilities

--- a/infrastructure/helm/backup-jobs/Chart.yaml
+++ b/infrastructure/helm/backup-jobs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: backup-jobs
+version: 0.1.0
+description: Helm chart for scheduled backup jobs
+type: application
+appVersion: "1.0"

--- a/infrastructure/helm/backup-jobs/templates/_helpers.tpl
+++ b/infrastructure/helm/backup-jobs/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "backup-jobs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "backup-jobs.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- $name = .Values.fullnameOverride -}}
+{{- end -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "backup-jobs.labels" -}}
+helm.sh/chart: {{ include "backup-jobs.chart" . }}
+{{ include "backup-jobs.selectorLabels" . }}
+{{- if .Chart.AppVersion -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "backup-jobs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "backup-jobs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "backup-jobs.chart" -}}
+{{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}

--- a/infrastructure/helm/backup-jobs/templates/cronjob.yaml
+++ b/infrastructure/helm/backup-jobs/templates/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "backup-jobs.fullname" . }}
+  labels: {{- include "backup-jobs.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: backup
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: BACKUP_BUCKET
+                  value: {{ .Values.bucket | quote }}
+                - name: MINIO_DATA_PATH
+                  value: {{ .Values.minioDataPath | quote }}
+              command: ["python", "/app/backup.py"]

--- a/infrastructure/helm/backup-jobs/values-dev.yaml
+++ b/infrastructure/helm/backup-jobs/values-dev.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: example/backup
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-backup-bucket
+minioDataPath: /data

--- a/infrastructure/helm/backup-jobs/values-prod.yaml
+++ b/infrastructure/helm/backup-jobs/values-prod.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: example/backup
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-backup-bucket
+minioDataPath: /data

--- a/infrastructure/helm/backup-jobs/values-staging.yaml
+++ b/infrastructure/helm/backup-jobs/values-staging.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: example/backup
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-backup-bucket
+minioDataPath: /data

--- a/infrastructure/helm/backup-jobs/values.yaml
+++ b/infrastructure/helm/backup-jobs/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: example/backup
+  tag: latest
+  pullPolicy: IfNotPresent
+schedule: "0 2 * * *"
+bucket: my-backup-bucket
+minioDataPath: /data

--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -1,0 +1,66 @@
+"""Backup Postgres and MinIO data to S3."""
+
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+
+def run(command: list[str]) -> None:
+    """Run a command and raise an error if it fails."""
+    subprocess.run(command, check=True)
+
+
+def dump_postgres(backup_dir: Path, bucket: str) -> None:
+    """
+    Dump Postgres database and upload to S3.
+
+    Args:
+        backup_dir: Directory to store the dump.
+        bucket: Name of the S3 bucket.
+    """
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    dump_file = backup_dir / f"postgres_{timestamp}.sql"
+    run(
+        [
+            "pg_dump",
+            os.getenv("PGDATABASE", "app"),
+            "-f",
+            str(dump_file),
+        ]
+    )
+    run(["aws", "s3", "cp", str(dump_file), f"s3://{bucket}/postgres/{dump_file.name}"])
+    dump_file.unlink()
+
+
+def backup_minio(data_path: Path, bucket: str) -> None:
+    """
+    Sync MinIO data directory to S3.
+
+    Args:
+        data_path: Local path to MinIO data.
+        bucket: Name of the S3 bucket.
+    """
+    run(
+        [
+            "aws",
+            "s3",
+            "sync",
+            str(data_path),
+            f"s3://{bucket}/minio/",
+        ]
+    )
+
+
+def main() -> None:
+    """Run database and object storage backups."""
+    bucket = os.environ["BACKUP_BUCKET"]
+    backup_dir = Path(os.getenv("BACKUP_DIR", "/tmp"))
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    dump_postgres(backup_dir, bucket)
+    data_path = Path(os.getenv("MINIO_DATA_PATH", "/data"))
+    backup_minio(data_path, bucket)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add nightly backup CronJob chart
- implement `backup.py` script and Dockerfile
- document backup and restore process
- include backup page in Sphinx docs

## Testing
- `flake8 scripts/backup.py`
- `pydocstyle scripts/backup.py`
- `mypy scripts/backup.py`
- `black scripts/backup.py`
- `pytest -W error` *(fails: ModuleNotFoundError: No module named 'api_gateway')*

------
https://chatgpt.com/codex/tasks/task_b_6877e074658083319895f26e9656ba8c