### PR TITLE
Add PII purge and retention

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/privacy.py
+++ b/backend/signal-ingestion/src/signal_ingestion/privacy.py
@@ -1,0 +1,25 @@
+"""Utilities for purging personally identifiable information."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Regex patterns for basic PII detection
+PII_PATTERNS = [
+    re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+    re.compile(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b"),
+]
+
+
+def purge_text(text: str) -> str:
+    """Remove PII substrings from ``text``."""
+    result = text
+    for pattern in PII_PATTERNS:
+        result = pattern.sub("[REDACTED]", result)
+    return result
+
+
+def purge_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``row`` with any PII removed."""
+    return {k: purge_text(v) if isinstance(v, str) else v for k, v in row.items()}

--- a/backend/signal-ingestion/src/signal_ingestion/retention.py
+++ b/backend/signal-ingestion/src/signal_ingestion/retention.py
@@ -1,0 +1,17 @@
+"""Data retention utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Signal
+
+
+async def purge_old_signals(session: AsyncSession, days: int) -> None:
+    """Delete ``Signal`` rows older than ``days`` days."""
+    threshold = datetime.now(timezone.utc) - timedelta(days=days)
+    await session.execute(delete(Signal).where(Signal.timestamp < threshold))
+    await session.commit()

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
 
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"
+    signal_retention_days: int = 90
 
     class Config:
         """Pydantic configuration for ``Settings``."""

--- a/backend/signal-ingestion/tests/test_privacy.py
+++ b/backend/signal-ingestion/tests/test_privacy.py
@@ -1,0 +1,17 @@
+"""Tests for PII purging utilities."""
+
+from signal_ingestion.privacy import purge_row
+
+
+def test_purge_row_removes_email() -> None:
+    """Ensure email addresses are stripped from content."""
+    row = {"content": "Contact me at user@example.com"}
+    cleaned = purge_row(row)
+    assert "user@example.com" not in cleaned["content"]
+
+
+def test_purge_row_removes_phone() -> None:
+    """Ensure phone numbers are stripped from content."""
+    row = {"content": "Call 123-456-7890 now"}
+    cleaned = purge_row(row)
+    assert "123-456-7890" not in cleaned["content"]

--- a/backend/signal-ingestion/tests/test_retention.py
+++ b/backend/signal-ingestion/tests/test_retention.py
@@ -1,0 +1,37 @@
+"""Tests for signal retention routines."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from signal_ingestion import database
+from signal_ingestion.models import Signal
+from signal_ingestion.retention import purge_old_signals
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_signals() -> None:
+    """Remove signals older than the retention threshold."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    database.engine = engine
+    database.SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    await database.init_db()
+
+    async with database.SessionLocal() as session:
+        old_ts = datetime.now(timezone.utc) - timedelta(days=100)
+        new_ts = datetime.now(timezone.utc)
+        session.add_all(
+            [
+                Signal(source="t", content="{}", timestamp=old_ts),
+                Signal(source="t", content="{}", timestamp=new_ts),
+            ]
+        )
+        await session.commit()
+        await purge_old_signals(session, 90)
+        remaining = (await session.execute(select(Signal))).scalars().all()
+        assert len(remaining) == 1
+        assert remaining[0].timestamp == new_ts.replace(tzinfo=None)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   privacy
 
 
 Kafka Utilities

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,17 @@
+# Data Privacy
+
+This project stores user generated signals and analytics metrics. To comply with privacy requirements we remove personally identifiable information (PII) and delete old records.
+
+## PII Purging
+
+Incoming signal data is sanitized by `signal_ingestion.privacy.purge_row`, which strips email addresses and phone numbers before a signal is persisted.
+
+## Data Retention
+
+Signals older than the configured `signal_retention_days` setting (default: 90 days) are removed by `signal_ingestion.retention.purge_old_signals`. Analytics logs should be pruned on the same schedule.
+
+## Compliance Steps
+
+1. Set the retention period in the environment if different from the default.
+2. Schedule periodic execution of the retention routine.
+3. Ensure documentation is built and published on every commit to main.


### PR DESCRIPTION
## Summary
- add privacy utilities for automated PII purging
- implement data retention logic
- document privacy and retention policies
- test privacy and retention helpers

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/src/signal_ingestion/retention.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/tests/test_privacy.py backend/signal-ingestion/tests/test_retention.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/src/signal_ingestion/retention.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/signal-ingestion/tests/test_privacy.py backend/signal-ingestion/tests/test_retention.py`
- `PYTHONPATH=backend/signal-ingestion/src pytest backend/signal-ingestion/tests/test_privacy.py backend/signal-ingestion/tests/test_retention.py -W error -vv`

------
https://chatgpt.com/codex/tasks/task_b_6877e080d9808331b841d6245950b009