### PR TITLE
Enable Next.js code splitting and ISR

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,12 @@ module.exports = {
       version: 'detect',
     },
   },
+  globals: {
+    jest: 'readonly',
+    describe: 'readonly',
+    it: 'readonly',
+    test: 'readonly',
+    expect: 'readonly',
+  },
   rules: {},
 };

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+This directory contains Next.js applications. Build-time environment variables are loaded from `.env` files during `next build`.
+
+The admin dashboard uses the following variables at build time:
+
+- `REACT_APP_API_URL` – base URL for backend API requests.
+- `REACT_APP_AUTH_TOKEN` – development authentication token.
+
+Create a `.env` file based on `.env.example` before running `npm run build`.

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  swcMinify: true,
+  webpack(config) {
+    config.optimization.usedExports = true;
+    config.optimization.splitChunks = { chunks: 'all' };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/frontend/admin-dashboard/package.json
+++ b/frontend/admin-dashboard/package.json
@@ -40,5 +40,6 @@
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5"
-  }
+  },
+  "sideEffects": false
 }

--- a/frontend/admin-dashboard/src/pages/_app.tsx
+++ b/frontend/admin-dashboard/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
-import AdminLayout from '../layouts/AdminLayout';
+import dynamic from 'next/dynamic';
+
+const AdminLayout = dynamic(() => import('../layouts/AdminLayout'));
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}
+
 export default function AbTestsPage() {
   return <div>AB Tests page placeholder.</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}
+
 export default function GalleryPage() {
   return <div>Gallery page placeholder.</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}
+
 export default function HeatmapPage() {
   return <div>Heatmap page placeholder.</div>;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/index.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}
+
 export default function DashboardPage() {
   return <div>Signal stream coming soon.</div>;
 }


### PR DESCRIPTION
## Summary
- add globals for Jest in ESlint config
- enable tree-shaking and code splitting in Next.js
- dynamically load the admin layout
- enable incremental static regeneration for dashboard pages
- document frontend build variables

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6877e089e1588331951b1e6474f740e5