### PR TITLE
Add consumer schema tests

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
+    model_config = SettingsConfigDict(env_file=".env")
+
     app_name: str = "marketplace-publisher"
     log_level: str = "INFO"
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost/db"
-
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
 
 
 settings = Settings()

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     """Configuration loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=".env")
 
     app_name: str = "monitoring"
     log_file: str = "app.log"
-
-    class Config:
-        """Pydantic configuration."""
-
-        env_file = ".env"
 
 
 settings = Settings()

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
+    model_config = SettingsConfigDict(env_file=".env")
+
     app_name: str = "service-template"
     log_level: str = "INFO"
-
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
 
 
 settings = Settings()

--- a/backend/shared/kafka/schema_registry.py
+++ b/backend/shared/kafka/schema_registry.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 
 class SchemaRegistryClient:
@@ -31,4 +31,4 @@ class SchemaRegistryClient:
             timeout=5,
         )
         response.raise_for_status()
-        return json.loads(response.text)
+        return cast(Dict[str, Any], json.loads(response.text))

--- a/backend/shared/kafka/utils.py
+++ b/backend/shared/kafka/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Iterable, Iterator, Tuple
 
 from jsonschema import validate
 from kafka import KafkaConsumer, KafkaProducer
@@ -48,7 +48,7 @@ class KafkaConsumerWrapper:
         self._registry = registry
         self._schemas = {topic: registry.fetch(f"{topic}-value") for topic in topics}
 
-    def __iter__(self) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    def __iter__(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
         """Iterate over validated messages."""
         for message in self._consumer:
             value = message.value

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
+    model_config = SettingsConfigDict(env_file=".env")
+
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"
-
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
 
 
 settings = Settings()

--- a/tests/test_kafka_utils.py
+++ b/tests/test_kafka_utils.py
@@ -2,23 +2,28 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Iterator
 
 import pytest
 from jsonschema.exceptions import ValidationError
 
 from backend.shared.kafka.schema_registry import SchemaRegistryClient
-from backend.shared.kafka.utils import KafkaProducerWrapper
+from backend.shared.kafka.utils import KafkaConsumerWrapper, KafkaProducerWrapper
 
 
 class DummyProducer:
+    """Collect messages instead of sending them to Kafka."""
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the dummy producer."""
         self.sent: Dict[str, Any] = {}
 
-    def send(self, topic: str, value: Dict[str, Any]) -> None:  # type: ignore[override]
+    def send(self, topic: str, value: Dict[str, Any]) -> None:
+        """Record the produced message."""
         self.sent[topic] = value
 
     def flush(self) -> None:  # pragma: no cover
+        """Flush is a no-op for the dummy producer."""
         pass
 
 
@@ -43,3 +48,53 @@ def test_producer_validation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(ValidationError):
         producer.produce("signals", {"bad": "data"})
+
+
+class DummyMessage:
+    """Container for a consumed Kafka message."""
+
+    def __init__(self, topic: str, value: Dict[str, Any]) -> None:
+        """Initialize with a ``topic`` and ``value``."""
+        self.topic = topic
+        self.value = value
+
+
+class DummyConsumer:
+    """Yield predetermined messages instead of reading from Kafka."""
+
+    def __init__(self, messages: list[DummyMessage]) -> None:
+        """Store ``messages`` to be iterated over."""
+        self._messages = messages
+
+    def __iter__(self) -> Iterable[DummyMessage]:
+        """Yield each stored message."""
+        yield from self._messages
+
+
+def test_consumer_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure consumed messages are validated."""
+
+    registry = SchemaRegistryClient("http://registry")
+    schema = {
+        "type": "object",
+        "properties": {"id": {"type": "string"}},
+        "required": ["id"],
+    }
+    monkeypatch.setattr(registry, "fetch", lambda *_: schema)
+
+    messages = [
+        DummyMessage("signals", {"id": "1"}),
+        DummyMessage("signals", {"bad": "data"}),
+    ]
+
+    monkeypatch.setattr(
+        "backend.shared.kafka.utils.KafkaConsumer",
+        lambda *_, **__: DummyConsumer(messages),
+    )
+
+    consumer = KafkaConsumerWrapper("kafka:9092", registry, ["signals"])
+    iterator: Iterator[tuple[str, Dict[str, Any]]] = iter(consumer)
+    topic, value = next(iterator)
+    assert (topic, value) == ("signals", {"id": "1"})
+    with pytest.raises(ValidationError):
+        next(iterator)


### PR DESCRIPTION
## Summary
- update pydantic `Settings` to use `SettingsConfigDict`
- tighten Kafka consumer type hints
- add schema validation test for consumer

## Testing
- `mypy tests/test_kafka_utils.py backend/shared/kafka/utils.py backend/shared/kafka/schema_registry.py backend/monitoring/src/monitoring/settings.py backend/service-template/src/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py`
- `PYTHONPATH=backend/monitoring/src:backend/api-gateway/src:backend/marketplace-publisher/src:backend/mockup-generation:backend/signal-ingestion/src:backend/scoring-engine/scoring_engine:backend/service-template/src:$PYTHONPATH pytest -W error -vv tests/test_kafka_utils.py`
- `PYTHONPATH=backend/monitoring/src:backend/api-gateway/src:backend/marketplace-publisher/src:backend/mockup-generation:backend/signal-ingestion/src:backend/scoring-engine/scoring_engine:backend/service-template/src:$PYTHONPATH pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_6877e090f0a08331b2e8fdd15270c472