### PR TITLE
Add base Kubernetes manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ This repository contains the desAInz project. Use `scripts/setup_codex.sh` to in
 
 Run `scripts/register_schemas.py` after the Kafka and schema registry containers
 start to register the provided JSON schemas.
+
+Base Kubernetes manifests are available under `infrastructure/k8s`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ The `scripts` directory provides helper scripts for setting up storage and CDN r
 - `setup_storage.sh` – create the S3/MinIO bucket structure
 - `configure_cdn.sh` – create a CloudFront distribution
 - `invalidate_cache.sh` – invalidate CDN caches when mockups change
+- Base Kubernetes manifests can be found in `infrastructure/k8s` with instructions for
+  customizing them for local Minikube testing.
   This document merges the original project summary, system architecture, deployment guide, implementation plan and all earlier blueprint versions into one reference.
 
 ## Service Template

--- a/infrastructure/k8s/README.md
+++ b/infrastructure/k8s/README.md
@@ -1,0 +1,20 @@
+# Kubernetes Manifests
+
+This directory provides base Kubernetes manifests for the desAInz microservices. The files in `base/` define a generic Deployment, Service, ConfigMap and Secret. Replace the `placeholder` names with the actual service name and adjust the image repository, tag and environment variables as required.
+
+A `kustomization.yaml` is included so the base manifests can be deployed with Kustomize:
+
+```bash
+kubectl apply -k infrastructure/k8s/base
+```
+
+## Local Minikube
+
+A simple overlay is provided in `overlays/minikube/` to change the Service type to `NodePort` for local testing. Apply it with:
+
+```bash
+kubectl apply -k infrastructure/k8s/overlays/minikube
+```
+
+Use `minikube service <service-name>` to access the service on your host machine.
+

--- a/infrastructure/k8s/base/configmap.yaml
+++ b/infrastructure/k8s/base/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder-config
+data:
+  EXAMPLE_ENV: "value"

--- a/infrastructure/k8s/base/deployment.yaml
+++ b/infrastructure/k8s/base/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: placeholder
+  labels:
+    app: placeholder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: placeholder
+  template:
+    metadata:
+      labels:
+        app: placeholder
+    spec:
+      containers:
+        - name: placeholder
+          image: example/placeholder:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: placeholder-config
+            - secretRef:
+                name: placeholder-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+  - secret.yaml

--- a/infrastructure/k8s/base/secret.yaml
+++ b/infrastructure/k8s/base/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: placeholder-secret
+type: Opaque
+stringData:
+  SECRET_KEY: "change-me"

--- a/infrastructure/k8s/base/service.yaml
+++ b/infrastructure/k8s/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: placeholder
+spec:
+  type: ClusterIP
+  selector:
+    app: placeholder
+  ports:
+    - port: 80
+      targetPort: 80

--- a/infrastructure/k8s/overlays/minikube/kustomization.yaml
+++ b/infrastructure/k8s/overlays/minikube/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: Service
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: placeholder
+      spec:
+        type: NodePort


### PR DESCRIPTION
## Summary
- add Kubernetes manifests under `infrastructure/k8s`
- document manifests and minikube overlay
- mention manifests in README docs

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: eslint errors)*
- `pre-commit run --files README.md docs/README.md infrastructure/k8s/README.md infrastructure/k8s/base/deployment.yaml infrastructure/k8s/base/service.yaml infrastructure/k8s/base/configmap.yaml infrastructure/k8s/base/secret.yaml infrastructure/k8s/base/kustomization.yaml infrastructure/k8s/overlays/minikube/kustomization.yaml` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_b_6877e09f1384833189806078149569e5