### PR TITLE
Implement image validation and compression

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -6,8 +6,9 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-import requests
+import requests  # type: ignore[import-untyped]
 from diffusers import StableDiffusionXLPipeline
+from PIL import Image
 import torch
 
 
@@ -25,7 +26,10 @@ class GenerationResult:
 class MockupGenerator:
     """Generate mockups using Stable Diffusion XL with fallback."""
 
-    def __init__(self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0") -> None:
+    def __init__(
+        self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0"
+    ) -> None:
+        """Initialize the generator with the given model ID."""
         self.model_id = model_id
         self.pipeline: Optional[StableDiffusionXLPipeline] = None
 
@@ -33,17 +37,24 @@ class MockupGenerator:
         """Load the diffusion pipeline on GPU if available."""
         if self.pipeline is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(device)
+            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(
+                device
+            )
             self.pipeline.enable_attention_slicing()
 
-    def generate(self, prompt: str, output_path: str, *, num_inference_steps: int = 30) -> GenerationResult:
+    def generate(
+        self, prompt: str, output_path: str, *, num_inference_steps: int = 30
+    ) -> GenerationResult:
         """Generate an image or fall back to external API on failure."""
         from time import perf_counter
 
         self.load()
+        assert self.pipeline is not None
         start = perf_counter()
         try:
-            image = self.pipeline(prompt=prompt, num_inference_steps=num_inference_steps).images[0]
+            image = self.pipeline(
+                prompt=prompt, num_inference_steps=num_inference_steps
+            ).images[0]
         except Exception as exc:  # pylint: disable=broad-except
             logger.warning("Local generation failed: %s. Falling back to API", exc)
             image = self._fallback_api(prompt)
@@ -51,7 +62,7 @@ class MockupGenerator:
         image.save(output_path)
         return GenerationResult(image_path=output_path, duration=duration)
 
-    def _fallback_api(self, prompt: str):
+    def _fallback_api(self, prompt: str) -> Image.Image:
         """Call external API as a fallback mechanism."""
         response = requests.post(
             "https://api.example.com/generate",
@@ -60,6 +71,5 @@ class MockupGenerator:
         )
         response.raise_for_status()
         from io import BytesIO
-        from PIL import Image
 
         return Image.open(BytesIO(response.content))

--- a/backend/mockup-generation/mockup_generation/post_processor.py
+++ b/backend/mockup-generation/mockup_generation/post_processor.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, cast
 
 import cv2
 import numpy
-from PIL import Image, ImageCms
+from PIL import Image
 
 
 def remove_background(image: Image.Image) -> Image.Image:
@@ -30,5 +30,23 @@ def convert_to_cmyk(image: Image.Image) -> Image.Image:
 def validate_dpi(image_path: Path, expected_dpi: Tuple[int, int] = (300, 300)) -> bool:
     """Validate that image has the required DPI."""
     image = Image.open(image_path)
-    dpi = image.info.get("dpi", expected_dpi)
+    dpi = cast(Tuple[int, int], image.info.get("dpi", expected_dpi))
     return dpi == expected_dpi
+
+
+def validate_color_space(image: Image.Image, expected_mode: str = "CMYK") -> bool:
+    """Return ``True`` if the image uses the expected color space."""
+    return image.mode == expected_mode
+
+
+def validate_dpi_image(
+    image: Image.Image, expected_dpi: Tuple[int, int] = (300, 300)
+) -> bool:
+    """Return ``True`` if ``image`` has the given DPI metadata."""
+    dpi = cast(Tuple[int, int], image.info.get("dpi", expected_dpi))
+    return dpi == expected_dpi
+
+
+def compress_image(image: Image.Image, output_path: Path) -> None:
+    """Save ``image`` using lossless compression."""
+    image.save(output_path, format="PNG", optimize=True, compress_level=9)

--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -17,7 +17,12 @@ class PromptContext:
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
-TEMPLATE = Template("A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}")
+TEMPLATE = Template(
+    (
+        "A {{ style }} design featuring {{ keywords | join(', ') }}."
+        " {{ extra.get('note', '') }}"
+    )
+)
 
 
 def build_prompt(context: PromptContext) -> str:

--- a/backend/mockup-generation/mockup_generation/tasks.py
+++ b/backend/mockup-generation/mockup_generation/tasks.py
@@ -8,13 +8,20 @@ from PIL import Image
 from .celery_app import app
 from .generator import MockupGenerator
 from .prompt_builder import PromptContext, build_prompt
-from .post_processor import convert_to_cmyk, remove_background, validate_dpi
+from .post_processor import (
+    compress_image,
+    convert_to_cmyk,
+    remove_background,
+    validate_color_space,
+    validate_dpi,
+    validate_dpi_image,
+)
 
 
 generator = MockupGenerator()
 
 
-@app.task
+@app.task  # type: ignore[misc]
 def generate_mockup(keywords: list[str], output_dir: str) -> str:
     """Generate a mockup asynchronously."""
     context = PromptContext(keywords=keywords)
@@ -24,7 +31,11 @@ def generate_mockup(keywords: list[str], output_dir: str) -> str:
 
     processed = remove_background(Image.open(result.image_path))
     processed = convert_to_cmyk(processed)
-    processed.save(result.image_path)
-    if not validate_dpi(result.image_path):
+    if not validate_color_space(processed):
+        raise ValueError("Invalid color space")
+    if not validate_dpi_image(processed):
+        raise ValueError("Invalid DPI")
+    compress_image(processed, Path(result.image_path))
+    if not validate_dpi(Path(result.image_path)):
         raise ValueError("Invalid DPI")
     return str(result.image_path)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   marketplace_file_sizes
 
 
 Kafka Utilities

--- a/docs/marketplace_file_sizes.md
+++ b/docs/marketplace_file_sizes.md
@@ -1,0 +1,9 @@
+# Marketplace File Size Recommendations
+
+The following table lists recommended dimensions and maximum file sizes for each supported marketplace.
+
+| Marketplace     | Dimensions | Max File Size | Formats  |
+|-----------------|------------|---------------|----------|
+| Redbubble       | 3000x3000px| 50MB          | PNG/JPG  |
+| Amazon Merch    | 4500x5400px| 25MB          | PNG      |
+| Etsy            | 2000x2000px| 20MB          | PNG/JPG  |


### PR DESCRIPTION
## Summary
- ensure generated images validate DPI and color space before saving
- compress mockups with lossless PNG before upload
- document marketplace file size recommendations

## Testing
- `docformatter --in-place --recursive backend/mockup-generation/mockup_generation docs`
- `flake8 backend/mockup-generation/mockup_generation docs`
- `black --check backend/mockup-generation/mockup_generation docs`
- `mypy --config-file pyproject.toml backend/mockup-generation/mockup_generation`
- `pytest -W error` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0a6fd9c833184349645b43a0168