### PR TITLE
Configure daily staging deployment

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to Staging
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Kubernetes
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.0'
+      - name: Mirror secrets from production
+        run: |
+          ./scripts/sync_staging_secrets.sh prod staging
+      - name: Deploy services
+        run: |
+          for svc in orchestrator ai-mockup-generation data-storage signal-ingestion scoring-engine marketplace-publisher feedback-loop; do
+            ./scripts/deploy.sh "$svc" "example/$svc:main" staging
+          done
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   staging_manual_qa
 
 
 Kafka Utilities

--- a/docs/staging_manual_qa.md
+++ b/docs/staging_manual_qa.md
@@ -1,0 +1,20 @@
+# Manual QA in Staging
+
+This document describes the steps for verifying new changes in the staging environment.
+
+1. **Deploy latest code**: The `Deploy to Staging` workflow runs every day. Ensure the workflow succeeded for the commit you want to test.
+2. **Verify service health**:
+   - Run `kubectl get pods -n staging` and confirm all pods are running.
+   - Check application logs for errors using `kubectl logs`.
+3. **Smoke test APIs**:
+   - Use the API Gateway base URL for staging.
+   - Test critical endpoints with `curl` or Postman.
+4. **Check the admin dashboard**:
+   - Navigate to the staging dashboard URL.
+   - Log in with staging credentials and exercise key flows such as viewing metrics and triggering jobs.
+5. **Data validation**:
+   - Inspect the staging database or storage bucket to ensure data is processed correctly.
+6. **Report issues**:
+   - File a GitHub issue with screenshots or logs if any checks fail.
+
+These checks help catch regressions before promoting a release to production.

--- a/infrastructure/helm/README.md
+++ b/infrastructure/helm/README.md
@@ -24,3 +24,13 @@ helm install <release-name> ./<microservice> -f ./<microservice>/values-<env>.ya
 
 Replace `<microservice>` with one of the service directories above and `<env>`
 with `dev`, `staging` or `prod`.
+
+### Mirroring Production in Staging
+
+Use `scripts/sync_staging_secrets.sh` to copy production secrets to the staging namespace so that staging closely matches the production environment:
+
+```bash
+./scripts/sync_staging_secrets.sh prod staging
+```
+
+Deploy the services with the staging values files to complete the mirror.

--- a/scripts/sync_staging_secrets.sh
+++ b/scripts/sync_staging_secrets.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Sync production secrets to the staging namespace.
+#
+# Usage: ./scripts/sync_staging_secrets.sh <prod-namespace> <staging-namespace>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <prod-namespace> <staging-namespace>" >&2
+  exit 1
+fi
+
+PROD_NS="$1"
+STAGING_NS="$2"
+
+kubectl get secrets -n "$PROD_NS" --no-headers -o custom-columns=:metadata.name |
+  while read -r secret; do
+    kubectl get secret "$secret" -n "$PROD_NS" -o yaml \
+      | sed "s/namespace: $PROD_NS/namespace: $STAGING_NS/" \
+      | kubectl apply -n "$STAGING_NS" -f -
+  done
+
+echo "Secrets from namespace $PROD_NS have been mirrored to $STAGING_NS."


### PR DESCRIPTION
## Summary
- sync production secrets to staging with `sync_staging_secrets.sh`
- automate daily staging deployments
- document manual QA steps for staging
- link manual QA doc in Sphinx index
- describe mirroring production configuration in Helm README

## Testing
- `npm ci --legacy-peer-deps`
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pip install -e .`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'monitoring')*
- `pre-commit run --files scripts/sync_staging_secrets.sh .github/workflows/staging-deploy.yml docs/staging_manual_qa.md docs/index.rst infrastructure/helm/README.md` *(fails: authentication to github.com)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0ad8ae88331b45dba64ad2a1572