### PR TITLE
Improve parallel ingestion and service concurrency

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import Optional
+from threading import Lock
 
-import requests
+import requests  # type: ignore[import-untyped]
 from diffusers import StableDiffusionXLPipeline
 import torch
+from PIL import Image
 
 
 logger = logging.getLogger(__name__)
@@ -25,25 +27,37 @@ class GenerationResult:
 class MockupGenerator:
     """Generate mockups using Stable Diffusion XL with fallback."""
 
-    def __init__(self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0") -> None:
+    def __init__(
+        self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0"
+    ) -> None:
         self.model_id = model_id
-        self.pipeline: Optional[StableDiffusionXLPipeline] = None
+        self.pipeline: StableDiffusionXLPipeline | None = None
+        self._lock = Lock()
 
     def load(self) -> None:
         """Load the diffusion pipeline on GPU if available."""
-        if self.pipeline is None:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
-            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(device)
-            self.pipeline.enable_attention_slicing()
+        with self._lock:
+            if self.pipeline is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                self.pipeline = StableDiffusionXLPipeline.from_pretrained(
+                    self.model_id
+                ).to(device)
+                self.pipeline.enable_attention_slicing()
 
-    def generate(self, prompt: str, output_path: str, *, num_inference_steps: int = 30) -> GenerationResult:
+    def generate(
+        self, prompt: str, output_path: str, *, num_inference_steps: int = 30
+    ) -> GenerationResult:
         """Generate an image or fall back to external API on failure."""
         from time import perf_counter
 
         self.load()
         start = perf_counter()
         try:
-            image = self.pipeline(prompt=prompt, num_inference_steps=num_inference_steps).images[0]
+            with self._lock:
+                assert self.pipeline is not None
+                image = self.pipeline(
+                    prompt=prompt, num_inference_steps=num_inference_steps
+                ).images[0]
         except Exception as exc:  # pylint: disable=broad-except
             logger.warning("Local generation failed: %s. Falling back to API", exc)
             image = self._fallback_api(prompt)
@@ -51,7 +65,7 @@ class MockupGenerator:
         image.save(output_path)
         return GenerationResult(image_path=output_path, duration=duration)
 
-    def _fallback_api(self, prompt: str):
+    def _fallback_api(self, prompt: str) -> Image.Image:
         """Call external API as a fallback mechanism."""
         response = requests.post(
             "https://api.example.com/generate",

--- a/backend/scoring-engine/scoring_engine/scoring.py
+++ b/backend/scoring-engine/scoring_engine/scoring.py
@@ -29,9 +29,6 @@ class Signal:
         self.metadata = metadata
 
 
-_SCALER = StandardScaler()
-
-
 def compute_freshness(timestamp: datetime) -> float:
     """Return freshness score based on time decay in hours."""
     hours = (datetime.now(timezone.utc) - timestamp).total_seconds() / 3600
@@ -40,8 +37,9 @@ def compute_freshness(timestamp: datetime) -> float:
 
 def compute_engagement(current: float, median: float) -> float:
     """Z-score of engagement rate against median."""
+    scaler = StandardScaler()
     arr = np.array([[current], [median]])
-    scaled = _SCALER.fit_transform(arr)
+    scaled = scaler.fit_transform(arr)
     return float(scaled[0][0])
 
 

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -23,4 +23,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)
+        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]

--- a/backend/signal-ingestion/tests/test_concurrency.py
+++ b/backend/signal-ingestion/tests/test_concurrency.py
@@ -1,0 +1,45 @@
+"""Concurrency stress tests for ingestion."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy import text
+
+from signal_ingestion import database, ingestion
+from signal_ingestion.adapters.base import BaseAdapter
+from typing import cast
+
+
+class _Adapter:
+    def __init__(self, name: str, count: int) -> None:
+        self._name = name
+        self._count = count
+
+    async def fetch(self) -> list[dict[str, int]]:  # pragma: no cover - simple mock
+        return [{"id": i} for i in range(self._count)]
+
+
+@pytest.mark.asyncio()
+async def test_ingest_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ingest many signals concurrently without race conditions."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(database, "engine", engine)
+    monkeypatch.setattr(database, "SessionLocal", session_factory)
+    await database.init_db()
+
+    ingestion.ADAPTERS = cast(
+        list[BaseAdapter], [_Adapter(f"a{i}", 50) for i in range(5)]
+    )
+
+    store: set[str] = set()
+    monkeypatch.setattr(ingestion, "is_duplicate", store.__contains__)
+    monkeypatch.setattr(ingestion, "add_key", store.add)
+
+    await ingestion.ingest(session_factory())
+
+    async with session_factory() as session:
+        result = await session.execute(text("select count(*) from signals"))
+        count = result.scalar_one()
+    assert count == 250


### PR DESCRIPTION
## Summary
- run ingestion adapters concurrently using dedicated sessions
- avoid race conditions in scoring by removing shared scaler
- make mockup generation thread-safe with a lock
- ignore untyped tracing instrumentation
- add a stress test for concurrent ingestion

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/scoring-engine/scoring_engine/scoring.py backend/mockup-generation/mockup_generation/generator.py backend/signal-ingestion/tests/test_concurrency.py backend/shared/tracing.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/scoring-engine/scoring_engine/scoring.py backend/mockup-generation/mockup_generation/generator.py backend/signal-ingestion/tests/test_concurrency.py backend/shared/tracing.py`
- `pytest -q` *(fails: NoBrokersAvailable; ModuleNotFoundError: monitoring)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0b30a788331bd72ac4f484130bd