### PR TITLE
Add dynamic imports with profiling doc

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import requests
 from diffusers import StableDiffusionXLPipeline
+from PIL import Image
 import torch
 
 
@@ -25,7 +26,10 @@ class GenerationResult:
 class MockupGenerator:
     """Generate mockups using Stable Diffusion XL with fallback."""
 
-    def __init__(self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0") -> None:
+    def __init__(
+        self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0"
+    ) -> None:
+        """Initialize the generator with the given model identifier."""
         self.model_id = model_id
         self.pipeline: Optional[StableDiffusionXLPipeline] = None
 
@@ -33,17 +37,24 @@ class MockupGenerator:
         """Load the diffusion pipeline on GPU if available."""
         if self.pipeline is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(device)
+            self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(
+                device
+            )
             self.pipeline.enable_attention_slicing()
 
-    def generate(self, prompt: str, output_path: str, *, num_inference_steps: int = 30) -> GenerationResult:
+    def generate(
+        self, prompt: str, output_path: str, *, num_inference_steps: int = 30
+    ) -> GenerationResult:
         """Generate an image or fall back to external API on failure."""
         from time import perf_counter
 
         self.load()
         start = perf_counter()
         try:
-            image = self.pipeline(prompt=prompt, num_inference_steps=num_inference_steps).images[0]
+            assert self.pipeline is not None
+            image = self.pipeline(
+                prompt=prompt, num_inference_steps=num_inference_steps
+            ).images[0]
         except Exception as exc:  # pylint: disable=broad-except
             logger.warning("Local generation failed: %s. Falling back to API", exc)
             image = self._fallback_api(prompt)
@@ -51,7 +62,7 @@ class MockupGenerator:
         image.save(output_path)
         return GenerationResult(image_path=output_path, duration=duration)
 
-    def _fallback_api(self, prompt: str):
+    def _fallback_api(self, prompt: str) -> Image.Image:
         """Call external API as a fallback mechanism."""
         response = requests.post(
             "https://api.example.com/generate",

--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -17,9 +17,14 @@ class PromptContext:
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
-TEMPLATE = Template("A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}")
+TEMPLATE = Template(
+    (
+        "A {{ style }} design featuring {{ keywords | join(', ') }}. "
+        "{{ extra.get('note', '') }}"
+    )
+)
 
 
 def build_prompt(context: PromptContext) -> str:
     """Return a formatted prompt string."""
-    return TEMPLATE.render(**context.__dict__)
+    return str(TEMPLATE.render(**context.__dict__))

--- a/frontend/admin-dashboard/src/features/AbTests.tsx
+++ b/frontend/admin-dashboard/src/features/AbTests.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AbTests() {
+  return <div>AB Tests page placeholder.</div>;
+}

--- a/frontend/admin-dashboard/src/features/Dashboard.tsx
+++ b/frontend/admin-dashboard/src/features/Dashboard.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Dashboard() {
+  return <div>Signal stream coming soon.</div>;
+}

--- a/frontend/admin-dashboard/src/features/Gallery.tsx
+++ b/frontend/admin-dashboard/src/features/Gallery.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Gallery() {
+  return <div>Gallery page placeholder.</div>;
+}

--- a/frontend/admin-dashboard/src/features/Heatmap.tsx
+++ b/frontend/admin-dashboard/src/features/Heatmap.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Heatmap() {
+  return <div>Heatmap page placeholder.</div>;
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
@@ -1,5 +1,8 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
 
+const AbTests = dynamic(() => import('../../features/AbTests'));
+
 export default function AbTestsPage() {
-  return <div>AB Tests page placeholder.</div>;
+  return <AbTests />;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -1,5 +1,8 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
 
+const Gallery = dynamic(() => import('../../features/Gallery'));
+
 export default function GalleryPage() {
-  return <div>Gallery page placeholder.</div>;
+  return <Gallery />;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
@@ -1,5 +1,8 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
 
+const Heatmap = dynamic(() => import('../../features/Heatmap'));
+
 export default function HeatmapPage() {
-  return <div>Heatmap page placeholder.</div>;
+  return <Heatmap />;
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/index.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/index.tsx
@@ -1,5 +1,8 @@
+import dynamic from 'next/dynamic';
 import React from 'react';
 
+const Dashboard = dynamic(() => import('../../features/Dashboard'));
+
 export default function DashboardPage() {
-  return <div>Signal stream coming soon.</div>;
+  return <Dashboard />;
 }

--- a/frontend/docs/performance.md
+++ b/frontend/docs/performance.md
@@ -1,0 +1,16 @@
+# Dashboard Performance
+
+This document tracks the bundle sizes and optimizations for the admin dashboard.
+
+## Build profiling
+
+Attempting to run `next build --profile` failed due to a Tailwind CSS PostCSS
+plugin error:
+
+```
+Error: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install `@tailwindcss/postcss` and update your PostCSS configuration.
+```
+
+Dynamic imports have been added for dashboard features to keep bundles small.
+Once the Tailwind configuration is updated, rerun the profile build to capture
+bundle sizes.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
-from setuptools import setup, find_packages
+"""Package setup for desAInz."""
 
-setup(name='desAInz', version='0.1', packages=find_packages())
+from setuptools import find_packages, setup
+
+setup(name="desAInz", version="0.1", packages=find_packages())


### PR DESCRIPTION
## Summary
- use next/dynamic to lazy load dashboard features
- outline profiling attempt in `frontend/docs/performance.md`
- format generator utilities and add docstrings

## Testing
- `black . --check`
- `flake8 backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/generator.py setup.py`
- `mypy backend/mockup-generation/mockup_generation/prompt_builder.py backend/mockup-generation/mockup_generation/generator.py setup.py`
- `npm test` within `frontend/admin-dashboard`
- `npm run build` *(fails: Tailwind CSS PostCSS plugin error)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0b60ff0833196cc2ef7c8d11995