### PR TITLE
Implement marketplace validation and rate limiting

### DIFF
--- a/backend/marketplace-publisher/pyproject.toml
+++ b/backend/marketplace-publisher/pyproject.toml
@@ -14,6 +14,8 @@ requests = "*"
 sqlalchemy = "*"
 asyncpg = "*"
 selenium = "*"
+redis = "*"
+Pillow = "*"
 
 [tool.poetry.group.dev.dependencies]
 black = "*"

--- a/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py
@@ -1,0 +1,32 @@
+"""Simple Redis-based rate limiter."""
+
+from __future__ import annotations
+
+import redis
+
+
+class RateLimiter:
+    """Token-based rate limiting using Redis."""
+
+    def __init__(self, client: redis.Redis) -> None:
+        """Store the Redis ``client`` used for state."""
+        self._client = client
+
+    def acquire(self, key: str, limit: int, period: int = 86400) -> bool:
+        """Return ``True`` if a token is acquired for ``key`` within ``limit``."""
+        with self._client.pipeline() as pipe:
+            while True:
+                try:
+                    pipe.watch(key)
+                    current = int(pipe.get(key) or 0)
+                    if current >= limit:
+                        pipe.unwatch()
+                        return False
+                    pipe.multi()
+                    pipe.incr(key)
+                    if current == 0:
+                        pipe.expire(key, period)
+                    pipe.execute()
+                    return True
+                except redis.WatchError:
+                    continue

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.py
@@ -1,0 +1,48 @@
+"""Marketplace-specific validation and rate limit rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+import yaml
+from PIL import Image
+
+from .db import Marketplace
+
+
+@dataclass(frozen=True)
+class MarketplaceRule:
+    """Validation and rate-limit configuration for a marketplace."""
+
+    max_file_size: int
+    max_width: int
+    max_height: int
+    daily_upload_limit: int
+
+
+def load_rules(path: Path | None = None) -> Mapping[Marketplace, MarketplaceRule]:
+    """Load rules from the given YAML ``path``."""
+    if path is None:
+        path = Path(__file__).with_name("rules.yaml")
+    data: Dict[str, Any] = yaml.safe_load(path.read_text())
+    return {Marketplace(key): MarketplaceRule(**value) for key, value in data.items()}
+
+
+RULES = load_rules()
+
+
+def validate_design(marketplace: Marketplace, design_path: Path) -> None:
+    """Validate ``design_path`` using the rules for ``marketplace``."""
+    rule = RULES[marketplace]
+    size = design_path.stat().st_size
+    if size > rule.max_file_size:
+        raise ValueError(f"file too large: {size} > {rule.max_file_size}")
+    with Image.open(design_path) as img:
+        width, height = img.size
+    if width > rule.max_width or height > rule.max_height:
+        raise ValueError(
+            f"invalid dimensions: {width}x{height} exceeds"
+            f" {rule.max_width}x{rule.max_height}"
+        )

--- a/backend/marketplace-publisher/src/marketplace_publisher/rules.yaml
+++ b/backend/marketplace-publisher/src/marketplace_publisher/rules.yaml
@@ -1,0 +1,15 @@
+redbubble:
+  max_file_size: 10000000
+  max_width: 5000
+  max_height: 5000
+  daily_upload_limit: 50
+amazon_merch:
+  max_file_size: 15000000
+  max_width: 4500
+  max_height: 5400
+  daily_upload_limit: 25
+etsy:
+  max_file_size: 10000000
+  max_width: 3000
+  max_height: 3000
+  daily_upload_limit: 100

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     app_name: str = "marketplace-publisher"
     log_level: str = "INFO"
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost/db"
+    redis_url: str = "redis://localhost:6379/0"
 
     class Config:
         """Pydantic configuration for ``Settings``."""

--- a/backend/marketplace-publisher/tests/test_api.py
+++ b/backend/marketplace-publisher/tests/test_api.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
 
 
 def test_publish_and_progress(monkeypatch, tmp_path) -> None:
     """Publish design and check initial progress."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
     from marketplace_publisher.db import Marketplace
-    from marketplace_publisher.main import app
+    from marketplace_publisher.main import app, limiter
+    import fakeredis
+    from marketplace_publisher import db
+    db.init_db = lambda: None  # type: ignore
+    limiter._client = fakeredis.FakeRedis()
     from marketplace_publisher import publisher
 
     class DummyClient:
@@ -21,7 +30,9 @@ def test_publish_and_progress(monkeypatch, tmp_path) -> None:
 
     with TestClient(app) as client:
         design = tmp_path / "a.png"
-        design.write_text("img")
+        design.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
         response = client.post(
             "/publish",
             json={
@@ -41,3 +52,93 @@ def test_publish_and_progress(monkeypatch, tmp_path) -> None:
             "success",
             "failed",
         }
+
+
+def test_publish_validation_error(monkeypatch, tmp_path) -> None:
+    """Return 400 when validation fails."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher.db import Marketplace
+    from marketplace_publisher.main import app, limiter
+    import fakeredis
+    from marketplace_publisher import db
+    db.init_db = lambda: None  # type: ignore
+    limiter._client = fakeredis.FakeRedis()
+    from marketplace_publisher import publisher, rules
+
+    class DummyClient:
+        def publish_design(self, design_path, metadata):
+            return "1"
+
+    rules.RULES[Marketplace.redbubble] = rules.MarketplaceRule(
+        max_file_size=1,
+        max_width=10,
+        max_height=10,
+        daily_upload_limit=1,
+    )
+    limiter.acquire = lambda *args, **kwargs: True  # type: ignore
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+
+    with TestClient(app) as client:
+        design = tmp_path / "b.png"
+        design.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        resp = client.post(
+            "/publish",
+            json={
+                "marketplace": Marketplace.redbubble.value,
+                "design_path": str(design),
+                "metadata": {},
+            },
+        )
+        assert resp.status_code == 400
+
+
+def test_publish_rate_limit(monkeypatch, tmp_path) -> None:
+    """Return 429 when exceeding rate limit."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher.db import Marketplace
+    from marketplace_publisher.main import app, limiter
+    import fakeredis
+    from marketplace_publisher import db
+    db.init_db = lambda: None  # type: ignore
+    limiter._client = fakeredis.FakeRedis()
+    from marketplace_publisher import publisher, rules
+
+    class DummyClient:
+        def publish_design(self, design_path, metadata):
+            return "1"
+
+    rules.RULES[Marketplace.redbubble] = rules.MarketplaceRule(
+        max_file_size=100,
+        max_width=10,
+        max_height=10,
+        daily_upload_limit=1,
+    )
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+
+    with TestClient(app) as client:
+        design = tmp_path / "c.png"
+        design.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        first = client.post(
+            "/publish",
+            json={
+                "marketplace": Marketplace.redbubble.value,
+                "design_path": str(design),
+                "metadata": {},
+            },
+        )
+        assert first.status_code == 200
+        second = client.post(
+            "/publish",
+            json={
+                "marketplace": Marketplace.redbubble.value,
+                "design_path": str(design),
+                "metadata": {},
+            },
+        )
+        assert second.status_code == 429


### PR DESCRIPTION
## Summary
- add per-marketplace rules config
- validate mockups before publishing
- apply Redis-based rate limiting
- update settings for Redis URL
- extend tests for validation and limits

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/tests/test_api.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/marketplace-publisher/src/marketplace_publisher/rules.py`
- `docformatter -i backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/src/marketplace_publisher/rate_limiter.py backend/marketplace-publisher/src/marketplace_publisher/rules.py backend/marketplace-publisher/tests/test_api.py`
- `pytest backend/marketplace-publisher/tests/test_api.py` *(fails: OperationalError: no such table: publish_task)*

------
https://chatgpt.com/codex/tasks/task_b_6877e062dd28833186c4861254b20be0