### PR TITLE
Add health endpoints

### DIFF
--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+from typing import cast
 
 
 SECRET_KEY = "change_this"  # In production use env var
@@ -20,7 +21,7 @@ def create_access_token(data: Dict[str, Any]) -> str:
     to_encode = data.copy()
     expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return cast(str, jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
 
 
 def verify_token(
@@ -29,7 +30,9 @@ def verify_token(
     """Verify a JWT token and return the payload."""
     token = credentials.credentials
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = cast(
+            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        )
     except JWTError as exc:  # pragma: no cover
         # jose raises JWTError for all issues
         raise HTTPException(

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -7,4 +7,18 @@ from backend.shared.tracing import configure_tracing
 
 app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return service liveness."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Return service readiness."""
+    return {"status": "ready"}
+
+
 app.include_router(router)

--- a/backend/api-gateway/tests/test_auth.py
+++ b/backend/api-gateway/tests/test_auth.py
@@ -1,5 +1,10 @@
 """Tests for JWT auth middleware."""
 
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
 from fastapi.testclient import TestClient
 
 from api_gateway.main import app

--- a/backend/api-gateway/tests/test_health.py
+++ b/backend/api-gateway/tests/test_health.py
@@ -1,0 +1,22 @@
+"""Tests for health and readiness endpoints."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+
+from api_gateway.main import app
+
+client = TestClient(app)
+
+
+def test_health_ready() -> None:
+    """Health and readiness endpoints return expected status."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -1,5 +1,10 @@
 """Tests for routing logic."""
 
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
 from fastapi.testclient import TestClient
 
 from api_gateway.main import app

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -24,7 +24,7 @@ configure_tracing(app, settings.app_name)
 REQUEST_COUNTER = Counter("http_requests_total", "Total HTTP requests")
 
 
-@app.middleware("http")  # type: ignore[misc]
+@app.middleware("http")
 async def add_correlation_id(
     request: Request,
     call_next: Callable[[Request], Coroutine[None, None, Response]],
@@ -39,14 +39,14 @@ async def add_correlation_id(
     return response
 
 
-@app.get("/metrics")  # type: ignore[misc]
+@app.get("/metrics")
 async def metrics() -> Response:
     """Expose Prometheus metrics."""
     data = generate_latest()
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
 
-@app.get("/overview")  # type: ignore[misc]
+@app.get("/overview")
 async def overview() -> dict[str, float]:
     """Return basic system information."""
     return {
@@ -55,13 +55,13 @@ async def overview() -> dict[str, float]:
     }
 
 
-@app.get("/analytics")  # type: ignore[misc]
+@app.get("/analytics")
 async def analytics() -> dict[str, int]:
     """Return placeholder analytics dashboard data."""
     return {"active_users": 0, "error_rate": 0}
 
 
-@app.get("/logs")  # type: ignore[misc]
+@app.get("/logs")
 async def logs() -> dict[str, str]:
     """Return the latest application logs."""
     path = Path(settings.log_file)
@@ -69,6 +69,18 @@ async def logs() -> dict[str, str]:
         return {"logs": ""}
     lines = path.read_text(encoding="utf-8").splitlines()[-100:]
     return {"logs": "\n".join(lines)}
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return service liveness."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Return service readiness."""
+    return {"status": "ready"}
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pydantic_settings import BaseSettings
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     """Configuration loaded from environment variables."""
 
     app_name: str = "monitoring"

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -43,3 +43,15 @@ def get_optimizations() -> List[str]:
     """Return recommended cost optimizations."""
     analyzer = MetricsAnalyzer(store.get_metrics())
     return analyzer.recommend_optimizations()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return service liveness."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Return service readiness."""
+    return {"status": "ready"}

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -73,5 +73,17 @@ def score_signal() -> Response:
     return jsonify({"score": score, "cached": False})
 
 
+@app.get("/health")
+def health() -> Response:
+    """Return service liveness."""
+    return jsonify(status="ok")
+
+
+@app.get("/ready")
+def ready() -> Response:
+    """Return service readiness."""
+    return jsonify(status="ready")
+
+
 if __name__ == "__main__":
     app.run(debug=True, port=5002)

--- a/backend/scoring-engine/tests/test_health.py
+++ b/backend/scoring-engine/tests/test_health.py
@@ -1,0 +1,18 @@
+"""Tests for scoring engine health endpoints."""
+
+from flask.testing import FlaskClient
+
+from scoring_engine.app import app
+
+app.config.update(TESTING=True)
+client: FlaskClient = app.test_client()
+
+
+def test_health_ready() -> None:
+    """Health and readiness endpoints return status."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ready"}

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -23,4 +23,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)
+        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]

--- a/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
+++ b/infrastructure/helm/ai-mockup-generation/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}

--- a/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
+++ b/infrastructure/helm/marketplace-publisher/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}

--- a/infrastructure/helm/orchestrator/templates/deployment.yaml
+++ b/infrastructure/helm/orchestrator/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}

--- a/infrastructure/helm/scoring-engine/templates/deployment.yaml
+++ b/infrastructure/helm/scoring-engine/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}

--- a/infrastructure/helm/signal-ingestion/templates/deployment.yaml
+++ b/infrastructure/helm/signal-ingestion/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.service.port }}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,10 @@
 """Tests for the optimization API."""
 
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "backend" / "optimization"))
+
 from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
@@ -22,3 +27,13 @@ def test_add_metric_and_get_optimizations() -> None:
     response = client.get("/optimizations")
     assert response.status_code == 200
     assert response.json() != []
+
+
+def test_health_ready_endpoints() -> None:
+    """Health and readiness endpoints return status."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    response = client.get("/ready")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,5 +1,12 @@
 """Tests for the monitoring service."""
 
+from pathlib import Path
+import sys
+
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "monitoring" / "src")
+)
+
 from fastapi.testclient import TestClient
 
 from monitoring.main import app
@@ -21,3 +28,13 @@ def test_overview_endpoint() -> None:
     body = response.json()
     assert "cpu_percent" in body
     assert "memory_mb" in body
+
+
+def test_health_ready_endpoints() -> None:
+    """Health and readiness should return status."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    response = client.get("/ready")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}


### PR DESCRIPTION
## Summary
- add /health and /ready endpoints to microservices
- configure Helm charts to use new probes
- test new endpoints

## Testing
- `pytest backend/api-gateway/tests/test_health.py backend/scoring-engine/tests/test_health.py tests/test_monitoring.py tests/test_api.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6877e07afce883318db1d426c77909a0