### PR TITLE
Add environment examples and loading script

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,13 @@
+# Example development environment variables
+DATABASE_URL=postgresql://user:password@localhost:5432/desainz_dev
+REDIS_URL=redis://localhost:6379/0
+SECRET_KEY=dev_secret_key
+OPENAI_API_KEY=your_dev_openai_key
+HUGGINGFACE_TOKEN=your_dev_hf_token
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=desainz-dev
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+LOG_LEVEL=DEBUG
+APPROVE_PUBLISHING=false

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,13 @@
+# Example production environment variables
+DATABASE_URL=postgresql://user:password@prod-db:5432/desainz
+REDIS_URL=redis://prod-cache:6379/0
+SECRET_KEY=change_me
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+S3_ENDPOINT=https://storage.example.com
+S3_ACCESS_KEY=replace_me
+S3_SECRET_KEY=replace_me
+S3_BUCKET=desainz-prod
+KAFKA_BOOTSTRAP_SERVERS=prod-kafka:9092
+LOG_LEVEL=INFO
+APPROVE_PUBLISHING=true

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,13 @@
+# Example staging environment variables
+DATABASE_URL=postgresql://user:password@staging-db:5432/desainz
+REDIS_URL=redis://staging-cache:6379/0
+SECRET_KEY=change_me
+OPENAI_API_KEY=your_openai_key
+HUGGINGFACE_TOKEN=your_hf_token
+S3_ENDPOINT=https://staging-storage.example.com
+S3_ACCESS_KEY=replace_me
+S3_SECRET_KEY=replace_me
+S3_BUCKET=desainz-staging
+KAFKA_BOOTSTRAP_SERVERS=staging-kafka:9092
+LOG_LEVEL=INFO
+APPROVE_PUBLISHING=true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/_build/
 __pycache__/
 node_modules/
 flow-typed/
+.env
+.env.*
+!.env.*.example

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ The `blueprints` folder contains the full system blueprint.
 
 - [Design Idea Engine Complete Blueprint](blueprints/DesignIdeaEngineCompleteBlueprint.md)
 - [Sphinx Documentation](sphinx/index)
+- [Configuration](configuration.md)
 
 The `scripts` directory provides helper scripts for setting up storage and CDN resources:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,22 @@
+# Configuration
+
+This project uses environment variables for all runtime configuration. The
+example files `.env.dev.example`, `.env.staging.example` and
+`.env.prod.example` provide sample values for each deployment stage. Copy the
+appropriate file to `.env` and adjust the values before running services
+locally or in CI.
+
+| Variable | Description |
+| --- | --- |
+| `DATABASE_URL` | Database connection string |
+| `REDIS_URL` | Redis connection string |
+| `SECRET_KEY` | Secret key for cryptographic signing |
+| `OPENAI_API_KEY` | OpenAI API authentication token |
+| `HUGGINGFACE_TOKEN` | Hugging Face API token |
+| `S3_ENDPOINT` | URL of the object storage service |
+| `S3_ACCESS_KEY` | Object storage access key |
+| `S3_SECRET_KEY` | Object storage secret key |
+| `S3_BUCKET` | Bucket name for storing assets |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka broker list |
+| `LOG_LEVEL` | Logging verbosity |
+| `APPROVE_PUBLISHING` | Require publishing approval flag |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to desAInz's documentation!
    :caption: Contents:
 
    README
+   configuration
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
 

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Load environment variables from a file for local runs.
+# Usage: ./load-env.sh [env_file]
+# Defaults to .env if no file is specified.
+
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Environment file $ENV_FILE not found" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a


### PR DESCRIPTION
## Summary
- add example environment files for dev/staging/prod
- add `load-env.sh` helper script to export variables
- document environment variables and link from docs
- ignore `.env` files in `.gitignore`

## Testing
- `npm test` *(fails: 'test' is not defined)*
- `pytest -W error` *(fails: ModuleNotFoundError: No module named 'monitoring')*

------
https://chatgpt.com/codex/tasks/task_b_6877e07da20c8331b5d77d15a5d51ed1