### PR TITLE
Implement admin CSV exports

### DIFF
--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -1,10 +1,17 @@
 """API routes including REST and tRPC-compatible endpoints."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+import csv
+from io import StringIO
+from sqlalchemy import func, select
 
-from .auth import verify_token
+from backend.shared.db import session_scope
+from backend.shared.db.models import ABTest, Listing
+
+from .auth import require_role, verify_token
 
 router = APIRouter()
 
@@ -32,3 +39,54 @@ async def trpc_endpoint(
     if procedure == "ping":
         return {"result": {"message": "pong", "user": payload.get("sub")}}
     return {"error": f"Procedure '{procedure}' not found"}
+
+
+def _rows_to_csv(rows: Iterable[Iterable[Any]], headers: list[str]) -> str:
+    """Convert iterable rows to CSV string."""
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(headers)
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue()
+
+
+@router.get("/export/ab_tests")
+async def export_ab_tests(
+    _payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> StreamingResponse:
+    """Return A/B test results as a CSV file."""
+    with session_scope() as session:
+        rows = session.execute(
+            select(ABTest.id, ABTest.listing_id, ABTest.variant, ABTest.conversion_rate)
+        ).all()
+
+    csv_content = _rows_to_csv(rows, ["id", "listing_id", "variant", "conversion_rate"])
+    return StreamingResponse(
+        iter([csv_content]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=ab_tests.csv"},
+    )
+
+
+@router.get("/export/marketplace_stats")
+async def export_marketplace_stats(
+    _payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> StreamingResponse:
+    """Return marketplace listing statistics as a CSV file."""
+    with session_scope() as session:
+        rows = session.execute(
+            select(
+                Listing.id,
+                Listing.price,
+                func.count(ABTest.id).label("num_tests"),
+            )
+            .join(ABTest, ABTest.listing_id == Listing.id, isouter=True)
+            .group_by(Listing.id)
+        ).all()
+    csv_content = _rows_to_csv(rows, ["listing_id", "price", "num_tests"])
+    return StreamingResponse(
+        iter([csv_content]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=marketplace_stats.csv"},
+    )

--- a/backend/api-gateway/tests/test_exports.py
+++ b/backend/api-gateway/tests/test_exports.py
@@ -1,0 +1,56 @@
+"""Integration tests for CSV export endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from api_gateway.main import app
+from api_gateway.auth import create_access_token
+from backend.shared.db import session_scope
+from backend.shared.db.models import ABTest, Listing
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Populate the database with sample data."""
+    with session_scope() as session:
+        session.query(ABTest).delete()
+        session.query(Listing).delete()
+        listing = Listing(
+            mockup_id=1, price=9.99, created_at=datetime.now(timezone.utc)
+        )
+        session.add(listing)
+        session.flush()
+        session.add_all(
+            [
+                ABTest(listing_id=listing.id, variant="A", conversion_rate=0.1),
+                ABTest(listing_id=listing.id, variant="B", conversion_rate=0.2),
+            ]
+        )
+        session.commit()
+
+
+def _auth_headers() -> dict[str, str]:
+    token = create_access_token({"sub": "admin", "role": "admin"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_export_ab_tests() -> None:
+    """CSV export of A/B tests should include header and rows."""
+    resp = client.get("/export/ab_tests", headers=_auth_headers())
+    assert resp.status_code == 200
+    body = resp.text.splitlines()
+    assert body[0] == "id,listing_id,variant,conversion_rate"
+    assert len(body) == 3
+
+
+def test_export_marketplace_stats() -> None:
+    """CSV export of marketplace stats should aggregate tests."""
+    resp = client.get("/export/marketplace_stats", headers=_auth_headers())
+    assert resp.status_code == 200
+    body = resp.text.splitlines()
+    assert body[0] == "listing_id,price,num_tests"
+    assert body[1].endswith(",2")

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -12,10 +12,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost/db"
 
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     """Configuration loaded from environment variables."""
 
     app_name: str = "monitoring"
     log_file: str = "app.log"
 
-    class Config:
-        """Pydantic configuration."""
-
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -11,10 +11,7 @@ class Settings(BaseSettings):
     app_name: str = "service-template"
     log_level: str = "INFO"
 
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -11,10 +11,7 @@ class Settings(BaseSettings):
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"
 
-    class Config:
-        """Pydantic configuration for ``Settings``."""
-
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/docs/api_gateway_exports.md
+++ b/docs/api_gateway_exports.md
@@ -1,0 +1,7 @@
+# API Gateway CSV Exports
+
+Two endpoints allow downloading statistics as CSV files when authenticated with an admin role.
+
+`/export/ab_tests` returns all A/B test results with columns `id`, `listing_id`, `variant`, and `conversion_rate`.
+
+`/export/marketplace_stats` aggregates listings and the number of associated tests using columns `listing_id`, `price`, and `num_tests`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   api_gateway_exports
 
 
 Kafka Utilities


### PR DESCRIPTION
## Summary
- implement admin-only CSV export endpoints for A/B tests and marketplace stats
- add role-based access dependency
- disable tracing when `DISABLE_TRACING` env var is set
- use `SettingsConfigDict` to avoid pydantic warnings
- document new API export endpoints
- test the export endpoints

## Testing
- `DISABLE_TRACING=1 pytest backend/api-gateway/tests/test_exports.py backend/api-gateway/tests/test_auth.py backend/api-gateway/tests/test_routes.py -W error`

------
https://chatgpt.com/codex/tasks/task_b_6877e09de484833192043abcf17f1fd8