### PR TITLE
Implement standardized error responses

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -4,7 +4,9 @@ from fastapi import FastAPI
 
 from .routes import router
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
+add_fastapi_error_handlers(app)
 app.include_router(router)

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -15,11 +15,13 @@ from .settings import settings
 from .db import Marketplace, SessionLocal, create_task, get_task, init_db
 from .publisher import publish_with_retry
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
+add_fastapi_error_handlers(app)
 
 
 @app.on_event("startup")

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Request, Response
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
 
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 from .logging_config import configure_logging
 from .settings import settings
@@ -20,6 +21,7 @@ configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
+add_fastapi_error_handlers(app)
 
 REQUEST_COUNTER = Counter("http_requests_total", "Total HTTP requests")
 

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -8,12 +8,14 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
 
 app = FastAPI(title="Optimization Service")
 configure_tracing(app, "optimization")
+add_fastapi_error_handlers(app)
 store = MetricsStore()
 
 

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -8,6 +8,7 @@ import os
 from flask import Flask, Response, jsonify, request
 import redis
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_flask_error_handlers
 
 from datetime import datetime
 
@@ -16,6 +17,7 @@ from .weight_repository import get_weights, update_weights
 
 app = Flask(__name__)
 configure_tracing(app, "scoring-engine")
+add_flask_error_handlers(app)
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 redis_client = redis.Redis.from_url(REDIS_URL)
 

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -11,11 +11,13 @@ from fastapi import FastAPI, Request, Response
 from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
+add_fastapi_error_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/shared/error_handling.py
+++ b/backend/shared/error_handling.py
@@ -1,0 +1,74 @@
+"""Shared error response models and exception handlers."""
+
+from __future__ import annotations
+
+import logging
+
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+from flask import Flask, jsonify, request, Response as FlaskResponse
+from werkzeug.exceptions import HTTPException as FlaskHTTPException
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response model."""
+
+    error: str
+    trace_id: str
+
+
+async def _fastapi_http_exception_handler(
+    request: Request, exc: HTTPException
+) -> Response:
+    trace_id = getattr(request.state, "correlation_id", "")
+    content = ErrorResponse(error=str(exc.detail), trace_id=trace_id).model_dump()
+    return JSONResponse(status_code=exc.status_code, content=content)
+
+
+async def _fastapi_general_exception_handler(
+    request: Request, exc: Exception
+) -> Response:
+    trace_id = getattr(request.state, "correlation_id", "")
+    logging.getLogger(__name__).error(
+        "unhandled exception",
+        exc_info=exc,
+        extra={"correlation_id": trace_id},
+    )
+    content = ErrorResponse(
+        error="Internal server error", trace_id=trace_id
+    ).model_dump()
+    return JSONResponse(status_code=500, content=content)
+
+
+def add_fastapi_error_handlers(app: FastAPI) -> None:
+    """Register standard exception handlers on a FastAPI app."""
+    app.add_exception_handler(
+        HTTPException,
+        _fastapi_http_exception_handler,  # type: ignore[arg-type]
+    )
+    app.add_exception_handler(Exception, _fastapi_general_exception_handler)
+
+
+def _flask_handle_exception(exc: Exception) -> tuple[FlaskResponse, int]:
+    """Return standardized JSON for all Flask exceptions."""
+    trace_id = request.headers.get("X-Correlation-ID", "")
+    logging.getLogger(__name__).error(
+        "unhandled exception",
+        exc_info=exc,
+        extra={"correlation_id": trace_id},
+    )
+    if isinstance(exc, FlaskHTTPException):
+        status = int(exc.code or 500)
+        message = str(exc.description or "")
+    else:
+        status = 500
+        message = "Internal server error"
+    resp = ErrorResponse(error=message, trace_id=trace_id).model_dump()
+    return jsonify(resp), status
+
+
+def add_flask_error_handlers(app: Flask) -> None:
+    """Register standard exception handlers on a Flask app."""
+    app.register_error_handler(Exception, _flask_handle_exception)

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -15,11 +15,13 @@ from .ingestion import ingest
 from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
+from backend.shared.error_handling import add_fastapi_error_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
+add_fastapi_error_handlers(app)
 
 
 @app.on_event("startup")

--- a/tests/error_schema/test_flask_errors.py
+++ b/tests/error_schema/test_flask_errors.py
@@ -1,0 +1,30 @@
+"""Verify standardized error responses for Flask service."""
+
+# mypy: ignore-errors
+
+import sys
+from pathlib import Path
+from flask.testing import FlaskClient
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend" / "scoring-engine"))
+sys.path.insert(0, str(ROOT))
+from scoring_engine.app import app
+
+app.config.update(TESTING=True)
+
+
+def test_internal_error_response(monkeypatch) -> None:
+    """Unhandled exceptions should return standardized error."""
+    client: FlaskClient = app.test_client()
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("scoring_engine.weight_repository.get_weights", fail)
+    resp = client.get("/weights")
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert set(body) == {"error", "trace_id"}
+    assert body["error"]
+    assert body["trace_id"]

--- a/tests/error_schema/test_publisher_errors.py
+++ b/tests/error_schema/test_publisher_errors.py
@@ -1,0 +1,42 @@
+"""Verify standardized error responses."""
+
+# mypy: ignore-errors
+
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend" / "marketplace-publisher" / "src"))
+sys.path.insert(0, str(ROOT))
+import types
+
+if "selenium" not in sys.modules:
+    sel = types.ModuleType("selenium")
+    webdriver = types.ModuleType("webdriver")
+    firefox = types.ModuleType("firefox")
+    options = types.ModuleType("options")
+    options.Options = object
+    firefox.options = options
+    webdriver.firefox = firefox
+    sel.webdriver = webdriver
+    sys.modules["selenium"] = sel
+    sys.modules["selenium.webdriver"] = webdriver
+    sys.modules["selenium.webdriver.firefox"] = firefox
+    sys.modules["selenium.webdriver.firefox.options"] = options
+stub_publisher = types.ModuleType("marketplace_publisher.publisher")
+stub_publisher.publish_with_retry = lambda *a, **k: None
+sys.modules.setdefault("marketplace_publisher.publisher", stub_publisher)
+from marketplace_publisher.main import app
+
+
+def test_not_found_response(monkeypatch) -> None:
+    """Unknown task ID should return error schema."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    with TestClient(app) as client:
+        response = client.get("/progress/9999")
+        assert response.status_code == 404
+        body = response.json()
+        assert set(body) == {"error", "trace_id"}
+        assert body["error"]
+        assert body["trace_id"]


### PR DESCRIPTION
## Summary
- standardize error handling with new shared module
- capture unhandled exceptions with trace IDs
- install handlers across services
- add regression tests for error responses

## Testing
- `mypy --strict backend/shared/error_handling.py`
- `flake8 backend/shared/error_handling.py backend/service-template/src/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/monitoring/src/monitoring/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py tests/error_schema/test_publisher_errors.py tests/error_schema/test_flask_errors.py`
- `black backend/shared/error_handling.py backend/service-template/src/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/monitoring/src/monitoring/main.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `pytest tests/error_schema/test_publisher_errors.py tests/error_schema/test_flask_errors.py` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0aa69848331806a02e09d570589