### PR TITLE
Add notifications, feedback analysis and preferences

### DIFF
--- a/backend/feedback-loop/feedback_loop/__init__.py
+++ b/backend/feedback-loop/feedback_loop/__init__.py
@@ -1,14 +1,18 @@
 """Feedback loop service components."""
 
 from .ab_testing import ABTestManager, BudgetAllocation
-from .scheduler import setup_scheduler
 from .weight_updater import update_weights
 from .ingestion import ingest_metrics
+
+try:  # Optional dependency
+    from .scheduler import setup_scheduler
+except Exception:  # pragma: no cover - scheduler may depend on optional libs
+    setup_scheduler = None
 
 __all__ = [
     "ABTestManager",
     "BudgetAllocation",
-    "setup_scheduler",
     "update_weights",
     "ingest_metrics",
+    "setup_scheduler",
 ]

--- a/backend/feedback-loop/feedback_loop/analysis.py
+++ b/backend/feedback-loop/feedback_loop/analysis.py
@@ -1,0 +1,20 @@
+"""Utilities for analysing design performance."""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def highlight_low_performing(
+    df: pd.DataFrame, engagement_threshold: float = 0.1
+) -> list[int]:
+    """Return IDs of designs with engagement below the threshold."""
+    if "design_id" not in df.columns or "engagement_rate" not in df.columns:
+        logger.debug("missing required columns in metrics frame")
+        return []
+    low_df = df[df["engagement_rate"] < engagement_threshold]
+    return list(low_df["design_id"].astype(int).tolist())

--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -9,6 +9,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from .ab_testing import ABTestManager
 from .ingestion import ingest_metrics
+from .analysis import highlight_low_performing
 from .weight_updater import update_weights
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,9 @@ def setup_scheduler(
     def hourly_ingest() -> None:
         df = ingest_metrics(metrics_source)
         logger.info("processed metrics frame size %s", len(df))
+        low = highlight_low_performing(df)
+        if low:
+            logger.info("low performing designs %s", low)
 
     def nightly_update() -> None:
         weights = {

--- a/backend/feedback-loop/tests/test_analysis.py
+++ b/backend/feedback-loop/tests/test_analysis.py
@@ -1,0 +1,16 @@
+"""Tests for design performance analysis helpers."""
+
+import pandas as pd
+from feedback_loop.analysis import highlight_low_performing
+
+
+def test_highlight_low_performing() -> None:
+    """Ensure low performing designs are correctly identified."""
+    df = pd.DataFrame(
+        {
+            "design_id": [1, 2, 3],
+            "engagement_rate": [0.05, 0.2, 0.03],
+        }
+    )
+    result = highlight_low_performing(df, engagement_threshold=0.1)
+    assert result == [1, 3]

--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -1,0 +1,60 @@
+"""Notification helpers for publishing failures."""
+
+from __future__ import annotations
+
+import logging
+import os
+from email.message import EmailMessage
+from pathlib import Path
+import smtplib
+
+import requests  # type: ignore
+
+from .db import Marketplace
+
+logger = logging.getLogger(__name__)
+
+
+def _send_slack(message: str) -> None:
+    """Send a Slack message using the configured webhook."""
+    webhook = os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook:
+        logger.warning("SLACK_WEBHOOK_URL not configured")
+        return
+    try:
+        requests.post(webhook, json={"text": message}, timeout=5).raise_for_status()
+    except Exception as exc:  # pragma: no cover
+        logger.error("failed to send slack notification: %s", exc)
+
+
+def _send_email(message: str) -> None:
+    """Send an email using SMTP configuration."""
+    host = os.getenv("SMTP_HOST")
+    port = int(os.getenv("SMTP_PORT", "25"))
+    to_addr = os.getenv("NOTIFY_EMAIL_TO")
+    from_addr = os.getenv("NOTIFY_EMAIL_FROM")
+    if not (host and to_addr and from_addr):
+        logger.warning("email notification not configured")
+        return
+    email = EmailMessage()
+    email["Subject"] = "Publishing task failed"
+    email["From"] = from_addr
+    email["To"] = to_addr
+    email.set_content(message)
+    try:
+        with smtplib.SMTP(host, port) as smtp:
+            smtp.send_message(email)
+    except Exception as exc:  # pragma: no cover
+        logger.error("failed to send email notification: %s", exc)
+
+
+def notify_failure(task_id: int, marketplace: Marketplace, design_path: Path) -> None:
+    """Notify when a publishing task fails after retries."""
+    message = (
+        "Publishing task "
+        f"{task_id} for {marketplace.value} failed for design {design_path}"
+    )
+    if os.getenv("SLACK_WEBHOOK_URL"):
+        _send_slack(message)
+    else:
+        _send_email(message)

--- a/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .clients import AmazonMerchClient, EtsyClient, RedbubbleClient, SeleniumFallback
+from .notifications import notify_failure
 from .db import (
     Marketplace,
     PublishStatus,
@@ -54,3 +55,4 @@ async def publish_with_retry(
             await update_task_status(session, task_id, PublishStatus.success)
         else:
             await update_task_status(session, task_id, PublishStatus.failed)
+            notify_failure(task_id, marketplace, design_path)

--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -1,0 +1,61 @@
+"""Tests for publisher notification helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from marketplace_publisher.db import Marketplace
+from marketplace_publisher.notifications import notify_failure
+
+
+@pytest.mark.parametrize("use_slack", [True, False])
+def test_notify_failure(monkeypatch, use_slack: bool) -> None:
+    """Verify that notifications are sent via Slack or email."""
+    called = {}
+
+    if use_slack:
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://example.com")
+    else:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.setenv("SMTP_HOST", "localhost")
+        monkeypatch.setenv("SMTP_PORT", "25")
+        monkeypatch.setenv("NOTIFY_EMAIL_FROM", "a@b.com")
+        monkeypatch.setenv("NOTIFY_EMAIL_TO", "c@d.com")
+
+    def fake_post(url, json, timeout):  # type: ignore[unused-argument]
+        called["slack"] = url
+
+        class Resp:
+            def raise_for_status(self) -> None:  # noqa: D401
+                """No-op."""
+                return None
+
+        return Resp()
+
+    class DummySMTP:
+        def __init__(self, host: str, port: int) -> None:  # noqa: D401
+            called["smtp"] = f"{host}:{port}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def send_message(self, _msg):
+            called["sent"] = True
+
+    if use_slack:
+        monkeypatch.setattr(
+            "marketplace_publisher.notifications.requests.post",
+            fake_post,
+        )
+    else:
+        monkeypatch.setattr(
+            "marketplace_publisher.notifications.smtplib.SMTP",
+            DummySMTP,
+        )
+
+    notify_failure(1, Marketplace.redbubble, Path("d.png"))
+
+    assert called

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -16,5 +16,11 @@ Modules
 .. automodule:: marketplace_publisher.publisher
     :members:
 
+.. automodule:: marketplace_publisher.notifications
+    :members:
+
+.. automodule:: feedback_loop.analysis
+    :members:
+
 .. automodule:: monitoring.main
     :members:

--- a/frontend/admin-dashboard/__tests__/preferences.test.tsx
+++ b/frontend/admin-dashboard/__tests__/preferences.test.tsx
@@ -1,0 +1,10 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import PreferencesPage from '../src/pages/dashboard/preferences';
+
+test('toggles notification setting', () => {
+  render(<PreferencesPage />);
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeChecked();
+  fireEvent.click(checkbox);
+  expect(checkbox).not.toBeChecked();
+});

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import Link from 'next/link';
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex h-screen">
       <aside className="w-64 bg-gray-800 text-white p-4">
@@ -17,6 +21,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           </Link>
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             AB Tests
+          </Link>
+          <Link href="/dashboard/preferences" className="block hover:underline">
+            Preferences
           </Link>
         </nav>
       </aside>

--- a/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+
+interface Preferences {
+  receiveNotifications: boolean;
+}
+
+export default function PreferencesPage() {
+  const [prefs, setPrefs] = useState<Preferences>({
+    receiveNotifications: true,
+  });
+
+  useEffect(() => {
+    const raw = localStorage.getItem('prefs');
+    if (raw) {
+      setPrefs(JSON.parse(raw));
+    }
+  }, []);
+
+  function toggleNotifications() {
+    const next = {
+      ...prefs,
+      receiveNotifications: !prefs.receiveNotifications,
+    };
+    setPrefs(next);
+    localStorage.setItem('prefs', JSON.stringify(next));
+  }
+
+  return (
+    <div>
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          checked={prefs.receiveNotifications}
+          onChange={toggleNotifications}
+        />
+        <span>Enable Notifications</span>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- alert on publish failures via email or Slack
- detect low-performing designs in feedback loop
- surface user preferences in dashboard
- document new modules
- add unit tests

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/feedback-loop/feedback_loop/analysis.py backend/feedback-loop/tests/test_analysis.py backend/marketplace-publisher/tests/test_notifications.py`
- `mypy --ignore-missing-imports --follow-imports=skip backend/marketplace-publisher/src/marketplace_publisher/notifications.py backend/feedback-loop/feedback_loop/analysis.py`
- `PYTHONPATH=backend/feedback-loop pytest backend/feedback-loop/tests/test_analysis.py backend/marketplace-publisher/tests/test_notifications.py`
- `npx eslint frontend/admin-dashboard/src/pages/dashboard/preferences.tsx frontend/admin-dashboard/src/layouts/AdminLayout.tsx frontend/admin-dashboard/__tests__/preferences.test.tsx`
- `sphinx-build -b html docs docs/_build`

------
https://chatgpt.com/codex/tasks/task_b_6877e0ac12688331912ee1b0a19b14c2