### PR TITLE
Add manual listing override interface

### DIFF
--- a/backend/marketplace-publisher/tests/test_api.py
+++ b/backend/marketplace-publisher/tests/test_api.py
@@ -41,3 +41,42 @@ def test_publish_and_progress(monkeypatch, tmp_path) -> None:
             "success",
             "failed",
         }
+
+
+def test_update_and_retry(monkeypatch, tmp_path) -> None:
+    """Edit task metadata and trigger retry."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    from marketplace_publisher.db import Marketplace
+    from marketplace_publisher.main import app
+    from marketplace_publisher import publisher
+
+    class DummyClient:
+        def publish_design(self, design_path, metadata):
+            return "1"
+
+    publisher.CLIENTS[Marketplace.redbubble] = DummyClient()
+    publisher._fallback.publish = lambda *args, **kwargs: None  # type: ignore
+
+    with TestClient(app) as client:
+        design = tmp_path / "b.png"
+        design.write_text("img")
+        resp = client.post(
+            "/publish",
+            json={
+                "marketplace": Marketplace.redbubble.value,
+                "design_path": str(design),
+                "metadata": {"title": "t"},
+            },
+        )
+        task_id = resp.json()["task_id"]
+
+        resp = client.put(f"/tasks/{task_id}", json={"metadata": {"title": "x"}})
+        assert resp.status_code == 200
+
+        resp = client.get("/tasks")
+        assert resp.status_code == 200
+        tasks = {t["id"]: t for t in resp.json()}
+        assert tasks[task_id]["metadata"]["title"] == "x"
+
+        resp = client.post(f"/tasks/{task_id}/retry")
+        assert resp.status_code == 200

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   manual_publish
 
 
 Kafka Utilities

--- a/docs/manual_publish.rst
+++ b/docs/manual_publish.rst
@@ -1,0 +1,11 @@
+Manual Publishing Controls
+==========================
+
+The marketplace publisher exposes additional API endpoints for manual
+intervention. Administrators can edit a publish task's metadata before it is
+processed and re-trigger the workflow if necessary. All overrides are stored in
+an audit log for traceability.
+
+* ``GET /tasks`` – list existing publish tasks.
+* ``PUT /tasks/{task_id}`` – replace task metadata and reset its status.
+* ``POST /tasks/{task_id}/retry`` – enqueue the task for publishing again.

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '../../components/Button';
+
+interface Task {
+  id: number;
+  status: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export default function PublishTasksPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [metadataEdits, setMetadataEdits] = useState<Record<number, string>>(
+    {}
+  );
+
+  useEffect(() => {
+    fetch('/api/tasks')
+      .then((res) => res.json())
+      .then(setTasks)
+      .catch(() => setTasks([]));
+  }, []);
+
+  const retry = async (taskId: number) => {
+    await fetch(`/api/tasks/${taskId}/retry`, { method: 'POST' });
+  };
+
+  const save = async (taskId: number) => {
+    const payload = metadataEdits[taskId];
+    if (!payload) return;
+    await fetch(`/api/tasks/${taskId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ metadata: JSON.parse(payload) }),
+    });
+  };
+
+  return (
+    <div>
+      <h1>Publish Tasks</h1>
+      <ul>
+        {tasks.map((t) => (
+          <li key={t.id} className="mb-4">
+            <div>
+              #{t.id} - {t.status}
+            </div>
+            <textarea
+              defaultValue={JSON.stringify(t.metadata)}
+              onChange={(e) =>
+                setMetadataEdits({
+                  ...metadataEdits,
+                  [t.id]: e.target.value,
+                })
+              }
+              className="w-full border"
+            />
+            <Button onClick={() => save(t.id)} className="mr-2 mt-2">
+              Save
+            </Button>
+            <Button onClick={() => retry(t.id)} className="mt-2">
+              Retry
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enable metadata edits and retries for publishing tasks
- track admin overrides in new audit log table
- expose new API endpoints in marketplace publisher
- add dashboard page to trigger edits and retries
- document manual publishing controls
- test updated behavior

## Testing
- `npx eslint src/pages/dashboard/publish.tsx --max-warnings=0`
- `npx prettier --write src/pages/dashboard/publish.tsx`
- `stylelint src/pages/dashboard/publish.tsx` *(fails: ConfigurationError)*
- `black --check .`
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/db.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/tests/test_api.py`
- `mypy backend/marketplace-publisher/src/marketplace_publisher/main.py backend/marketplace-publisher/src/marketplace_publisher/db.py` *(fails: 15 errors in 3 files)*
- `sphinx-build -b html docs docs/_build`
- `PYTHONPATH=. pytest backend/marketplace-publisher/tests/test_api.py -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6877e0b07bb08331a2b84977b07092da