### PR TITLE
Add dependabot and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+### Summary
+Provide a concise description of the changes.
+
+### Regression tests
+- [ ] Added or updated tests to cover changes
+- [ ] All tests pass locally with `pytest -W error` and `npm test`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### Summary
+Provide a concise description of the changes.
+
+### Regression tests
+- [ ] Added or updated tests to cover changes
+- [ ] All tests pass locally with `pytest -W error` and `npm test`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to desAInz's documentation!
    README
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
+   maintenance
 
 
 Kafka Utilities

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,16 @@
+# Maintenance and Dependency Updates
+
+This project uses **GitHub Dependabot** to automatically propose updates for
+Python, JavaScript and GitHub Actions dependencies. Dependabot checks for new
+releases weekly and opens pull requests.
+
+## Reviewing updates
+
+- Ensure CI passes and verify that regression tests cover the change.
+- Apply code formatting with `pre-commit` before merging.
+- Merge security fixes promptly after tests succeed.
+
+## Manual updates
+
+For urgent updates run the appropriate package manager commands and open a pull
+request with accompanying regression tests.


### PR DESCRIPTION
## Summary
- add dependabot configuration
- add PR templates requesting regression tests
- document dependency update policy

## Testing
- `flake8 docs/maintenance.md docs/index.rst`
- `pytest -W error -vv` *(fails: ModuleNotFoundError: No module named 'monitoring')*
- `npm test` *(fails: eslint errors in tests)*

------
https://chatgpt.com/codex/tasks/task_b_6877e0bcf61083319f7722b15bfdaf3a