### PR TITLE
Implement role-based access control

### DIFF
--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -1,11 +1,13 @@
 """JWT authentication utilities."""
 
 from datetime import UTC, datetime, timedelta
-from typing import Any, Dict
+from typing import Any, Dict, Callable, cast
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+from backend.shared.db import session_scope
+from backend.shared.db.models import Role, UserRole
 
 
 SECRET_KEY = "change_this"  # In production use env var
@@ -20,7 +22,7 @@ def create_access_token(data: Dict[str, Any]) -> str:
     to_encode = data.copy()
     expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return str(jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM))
 
 
 def verify_token(
@@ -29,10 +31,34 @@ def verify_token(
     """Verify a JWT token and return the payload."""
     token = credentials.credentials
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = cast(
+            Dict[str, Any], jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        )
     except JWTError as exc:  # pragma: no cover
         # jose raises JWTError for all issues
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
         ) from exc
     return payload
+
+
+def require_role(required: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Dependency factory ensuring the user has the required role."""
+
+    def _verify(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
+        user_id = str(payload.get("sub"))
+        with session_scope() as session:
+            role = (
+                session.query(Role.name)
+                .join(UserRole)
+                .filter(UserRole.user_id == user_id)
+                .scalar()
+            )
+        if role != required:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role",
+            )
+        return payload
+
+    return _verify

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -2,11 +2,21 @@
 
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status as http_status
 
-from .auth import verify_token
+from .auth import require_role, verify_token
+from backend.shared.db import session_scope
+from backend.shared.db.models import Role, UserRole
+from pydantic import BaseModel
 
 router = APIRouter()
+
+
+class AssignRoleRequest(BaseModel):
+    """Request body for role assignment."""
+
+    user_id: str
+    role: str
 
 
 @router.get("/status")
@@ -17,10 +27,30 @@ async def status() -> Dict[str, str]:
 
 @router.get("/protected")
 async def protected(
-    payload: Dict[str, Any] = Depends(verify_token),
+    payload: Dict[str, Any] = Depends(require_role("viewer")),
 ) -> Dict[str, Any]:
-    """Protected endpoint requiring a valid token."""
+    """Protected endpoint requiring viewer role."""
     return {"user": payload.get("sub")}
+
+
+@router.post("/roles/assign")
+async def assign_role(
+    request: AssignRoleRequest,
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> Dict[str, str]:
+    """Assign a role to a user."""
+    with session_scope() as session:
+        role = session.query(Role).filter_by(name=request.role).one_or_none()
+        if role is None:
+            raise HTTPException(http_status.HTTP_400_BAD_REQUEST, "Unknown role")
+        existing = (
+            session.query(UserRole).filter_by(user_id=request.user_id).one_or_none()
+        )
+        if existing:
+            existing.role = role
+        else:
+            session.add(UserRole(user_id=request.user_id, role=role))
+    return {"status": "assigned"}
 
 
 @router.post("/trpc/{procedure}")
@@ -28,7 +58,7 @@ async def trpc_endpoint(
     procedure: str,
     payload: Dict[str, Any] = Depends(verify_token),
 ) -> Dict[str, Any]:
-    """tRPC-compatible endpoint."""
+    """TRPC-compatible endpoint."""
     if procedure == "ping":
         return {"result": {"message": "pong", "user": payload.get("sub")}}
     return {"error": f"Procedure '{procedure}' not found"}

--- a/backend/shared/db/migrations/api_gateway/versions/0002_add_roles.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0002_add_roles.py
@@ -1,0 +1,45 @@
+"""Add roles tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create role and user role tables and seed roles."""
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=50), nullable=False, unique=True),
+    )
+    op.create_table(
+        "user_roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.String(), index=True, nullable=False),
+        sa.Column("role_id", sa.Integer, sa.ForeignKey("roles.id")),
+    )
+    roles_table = sa.table(
+        "roles",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+    )
+    op.bulk_insert(
+        roles_table,
+        [
+            {"id": 1, "name": "admin"},
+            {"id": 2, "name": "editor"},
+            {"id": 3, "name": "viewer"},
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Drop role tables."""
+    op.drop_table("user_roles")
+    op.drop_table("roles")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -89,3 +89,26 @@ class ABTest(Base):
     conversion_rate: Mapped[float] = mapped_column(Float, default=0.0)
 
     listing: Mapped[Listing] = relationship(back_populates="tests")
+
+
+class Role(Base):
+    """User role type."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True)
+
+    user_roles: Mapped[list["UserRole"]] = relationship(back_populates="role")
+
+
+class UserRole(Base):
+    """Assignment of a role to a user."""
+
+    __tablename__ = "user_roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"))
+
+    role: Mapped[Role] = relationship(back_populates="user_roles")

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -23,4 +23,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)
+        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -18,6 +18,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             AB Tests
           </Link>
+          <Link href="/dashboard/roles" className="block hover:underline">
+            Roles
+          </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">

--- a/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+export default function RolesPage() {
+  const [userId, setUserId] = useState('');
+  const [role, setRole] = useState('viewer');
+
+  async function assign(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch('/roles/assign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId, role }),
+    });
+    setUserId('');
+  }
+
+  return (
+    <form onSubmit={assign} className="space-y-2">
+      <input
+        className="border p-2"
+        placeholder="User ID"
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+      />
+      <select
+        className="border p-2"
+        value={role}
+        onChange={(e) => setRole(e.target.value)}
+      >
+        <option value="admin">admin</option>
+        <option value="editor">editor</option>
+        <option value="viewer">viewer</option>
+      </select>
+      <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+        Assign Role
+      </button>
+    </form>
+  );
+}

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -1,0 +1,56 @@
+"""Tests for API Gateway role handling."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
+)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import engine, session_scope  # noqa: E402
+from backend.shared.db.base import Base  # noqa: E402
+from backend.shared.db.models import Role, UserRole  # noqa: E402
+
+client = TestClient(app)
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def test_assign_and_protected_access() -> None:
+    """User with assigned role can access endpoints."""
+    admin_token = create_access_token({"sub": "u1"})
+    viewer_token = create_access_token({"sub": "u2"})
+
+    with session_scope() as session:
+        admin_role = Role(id=1, name="admin")
+        session.add_all(
+            [
+                admin_role,
+                Role(id=2, name="editor"),
+                Role(id=3, name="viewer"),
+            ]
+        )
+        session.flush()
+        session.add(
+            UserRole(
+                user_id="u1",
+                role=admin_role,
+            )
+        )
+
+    resp = client.post(
+        "/roles/assign",
+        json={"user_id": "u2", "role": "viewer"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        "/protected",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `Role` and `UserRole` models with alembic migration
- enforce roles in API gateway auth layer
- add role assignment endpoint and viewer-protected route
- add React page to assign roles via dashboard
- test role management via FastAPI

## Testing
- `flake8 tests/test_api_gateway.py backend/api-gateway/src/api_gateway/auth.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/base.py backend/shared/db/models.py backend/shared/db/migrations/api_gateway/versions/0002_add_roles.py backend/shared/tracing.py`
- `pydocstyle tests/test_api_gateway.py backend/api-gateway/src/api_gateway/auth.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/models.py backend/shared/db/base.py backend/shared/db/migrations/api_gateway/versions/0002_add_roles.py backend/shared/tracing.py`
- `mypy backend/api-gateway/src/api_gateway/auth.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/models.py backend/shared/db/base.py backend/shared/tracing.py tests/test_api_gateway.py`
- `PYTHONPATH=backend/api-gateway/src:. pytest tests/test_api_gateway.py -W error`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_b_6877e063be3483318d142e6b551dc2f5