### PR TITLE
Add analytics service and dashboard widget

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -1,0 +1,82 @@
+"""Analytics service exposing experiment results."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from backend.shared.db import SessionLocal
+from backend.shared.db import models
+from backend.shared.tracing import configure_tracing
+
+app = FastAPI(title="Analytics Service")
+configure_tracing(app, "analytics")
+
+
+class ABTestSummary(BaseModel):
+    """Summary of results for an A/B test."""
+
+    ab_test_id: int
+    conversions: int
+    impressions: int
+
+
+class MarketplaceSummary(BaseModel):
+    """Aggregated metrics for a listing."""
+
+    listing_id: int
+    clicks: int
+    purchases: int
+    revenue: float
+
+
+@app.get("/ab_test_results/{ab_test_id}")
+def ab_test_results(ab_test_id: int) -> ABTestSummary:
+    """Return aggregated A/B test results."""
+    with SessionLocal() as session:
+        rows = (
+            session.query(models.ABTestResult)
+            .filter(models.ABTestResult.ab_test_id == ab_test_id)
+            .all()
+        )
+    conversions = sum(r.conversions for r in rows)
+    impressions = sum(r.impressions for r in rows)
+    return ABTestSummary(
+        ab_test_id=ab_test_id,
+        conversions=conversions,
+        impressions=impressions,
+    )
+
+
+@app.get("/marketplace_metrics/{listing_id}")
+def marketplace_metrics(listing_id: int) -> MarketplaceSummary:
+    """Return aggregated metrics for a listing."""
+    with SessionLocal() as session:
+        rows = (
+            session.query(models.MarketplaceMetric)
+            .filter(models.MarketplaceMetric.listing_id == listing_id)
+            .all()
+        )
+    clicks = sum(r.clicks for r in rows)
+    purchases = sum(r.purchases for r in rows)
+    revenue = sum(r.revenue for r in rows)
+    return MarketplaceSummary(
+        listing_id=listing_id,
+        clicks=clicks,
+        purchases=purchases,
+        revenue=revenue,
+    )
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    """Return service liveness."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> Dict[str, str]:
+    """Return service readiness."""
+    return {"status": "ready"}

--- a/backend/shared/db/__init__.py
+++ b/backend/shared/db/__init__.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from .base import Base
 
+__all__ = ["Base", "engine", "SessionLocal", "session_scope"]
+
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///shared.db")
 engine = create_engine(DATABASE_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
@@ -1,0 +1,20 @@
+"""Merge branch heads for linear history."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0003"
+down_revision = ("0002", "0002")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge branches by creating empty revision."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade by doing nothing."""
+    pass

--- a/backend/shared/db/migrations/scoring_engine/versions/0004_add_analytics_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0004_add_analytics_tables.py
@@ -1,0 +1,54 @@
+"""Add analytics tables for A/B tests and marketplace metrics."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create analytics tables."""
+    op.create_table(
+        "ab_test_results",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("ab_test_id", sa.Integer, sa.ForeignKey("ab_tests.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("conversions", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("impressions", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_index(
+        op.f("ix_ab_test_results_ab_test_id"),
+        "ab_test_results",
+        ["ab_test_id"],
+        unique=False,
+    )
+    op.create_table(
+        "marketplace_metrics",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("listing_id", sa.Integer, sa.ForeignKey("listings.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("clicks", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("purchases", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("revenue", sa.Float(), nullable=False, server_default="0"),
+    )
+    op.create_index(
+        op.f("ix_marketplace_metrics_listing_id"),
+        "marketplace_metrics",
+        ["listing_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop analytics tables."""
+    op.drop_index(
+        op.f("ix_marketplace_metrics_listing_id"), table_name="marketplace_metrics"
+    )
+    op.drop_table("marketplace_metrics")
+    op.drop_index(op.f("ix_ab_test_results_ab_test_id"), table_name="ab_test_results")
+    op.drop_table("ab_test_results")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -89,3 +89,32 @@ class ABTest(Base):
     conversion_rate: Mapped[float] = mapped_column(Float, default=0.0)
 
     listing: Mapped[Listing] = relationship(back_populates="tests")
+
+
+class ABTestResult(Base):
+    """Outcome metrics for an A/B test variant."""
+
+    __tablename__ = "ab_test_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ab_test_id: Mapped[int] = mapped_column(ForeignKey("ab_tests.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    conversions: Mapped[int] = mapped_column(Integer, default=0)
+    impressions: Mapped[int] = mapped_column(Integer, default=0)
+
+    ab_test: Mapped[ABTest] = relationship()
+
+
+class MarketplaceMetric(Base):
+    """Aggregated metrics for a marketplace listing."""
+
+    __tablename__ = "marketplace_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    listing_id: Mapped[int] = mapped_column(ForeignKey("listings.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    clicks: Mapped[int] = mapped_column(Integer, default=0)
+    purchases: Mapped[int] = mapped_column(Integer, default=0)
+    revenue: Mapped[float] = mapped_column(Float, default=0.0)
+
+    listing: Mapped[Listing] = relationship()

--- a/docs/api/backend.analytics.rst
+++ b/docs/api/backend.analytics.rst
@@ -1,0 +1,7 @@
+backend.analytics module
+========================
+
+.. automodule:: backend.analytics.api
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/backend.rst
+++ b/docs/api/backend.rst
@@ -13,3 +13,4 @@ Subpackages
    :maxdepth: 4
 
    backend.optimization
+   backend.analytics

--- a/frontend/admin-dashboard/__tests__/abTestSummary.test.tsx
+++ b/frontend/admin-dashboard/__tests__/abTestSummary.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { AbTestSummary } from '../src/components/AbTestSummary';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ conversions: 2, impressions: 5 }),
+  })
+) as jest.Mock;
+
+test('loads and displays summary', async () => {
+  render(<AbTestSummary abTestId={1} />);
+  expect(screen.getByTestId('abtest-loading')).toBeInTheDocument();
+  await waitFor(() => screen.getByTestId('abtest-summary'));
+  expect(screen.getByText(/Conversions/)).toBeInTheDocument();
+});

--- a/frontend/admin-dashboard/src/components/AbTestSummary.tsx
+++ b/frontend/admin-dashboard/src/components/AbTestSummary.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+
+interface Summary {
+  conversions: number;
+  impressions: number;
+}
+
+export function AbTestSummary({ abTestId }: { abTestId: number }) {
+  const [summary, setSummary] = useState<Summary | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/analytics/ab_test_results/${abTestId}`);
+      if (res.ok) {
+        setSummary(await res.json());
+      }
+    }
+    void load();
+  }, [abTestId]);
+
+  if (!summary) {
+    return <div data-testid="abtest-loading">Loading...</div>;
+  }
+  return (
+    <div data-testid="abtest-summary">
+      Conversions: {summary.conversions} / Impressions: {summary.impressions}
+    </div>
+  );
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { AbTestSummary } from '../../components/AbTestSummary';
 
 export default function AbTestsPage() {
   const { t } = useTranslation();
-  return <div>{t('abTestsPlaceholder')}</div>;
+  return (
+    <div>
+      <h1>{t('abTests')}</h1>
+      <AbTestSummary abTestId={1} />
+    </div>
+  );
 }

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,56 @@
+"""Tests for the analytics API."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from backend.analytics import api
+from backend.shared.db import Base, SessionLocal, engine, models
+
+
+def setup_module(module: object) -> None:
+    """Create tables in the temporary database."""
+    Base.metadata.create_all(engine)
+    with SessionLocal() as session:
+        ab_test = models.ABTest(listing_id=1, variant="A", conversion_rate=0)
+        session.add(ab_test)
+        session.commit()
+        session.refresh(ab_test)
+        session.add_all(
+            [
+                models.ABTestResult(
+                    ab_test_id=ab_test.id,
+                    conversions=5,
+                    impressions=10,
+                ),
+                models.ABTestResult(
+                    ab_test_id=ab_test.id,
+                    conversions=3,
+                    impressions=8,
+                ),
+            ]
+        )
+        session.add(
+            models.MarketplaceMetric(listing_id=1, clicks=20, purchases=2, revenue=40.0)
+        )
+        session.commit()
+
+
+def test_ab_test_results() -> None:
+    """Aggregated AB test results are returned."""
+    client = TestClient(api.app)
+    resp = client.get("/ab_test_results/1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["conversions"] == 8
+    assert body["impressions"] == 18
+
+
+def test_marketplace_metrics() -> None:
+    """Marketplace metrics endpoint aggregates rows."""
+    client = TestClient(api.app)
+    resp = client.get("/marketplace_metrics/1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["clicks"] == 20
+    assert body["purchases"] == 2
+    assert body["revenue"] == 40.0


### PR DESCRIPTION
## Summary
- create analytics microservice
- track AB test results and marketplace metrics in DB
- expose analytics REST endpoints
- surface results on admin dashboard
- document analytics API
- add tests for analytics service

## Testing
- `scripts/setup_codex.sh`
- `python -m flake8 backend/analytics/api.py backend/shared/db/models.py tests/test_analytics.py`
- `python -m mypy backend/analytics/api.py tests/test_analytics.py backend/shared/db/models.py backend/shared/db/__init__.py`
- `make lint` *(fails: E402, F401, etc.)*
- `make test` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_6877e7a210a8833197a6f62782b1f66e