### PR TITLE
Add role-based access control

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -1,5 +1,7 @@
 """API Gateway FastAPI application."""
 
+from __future__ import annotations
+
 from fastapi import FastAPI
 
 from .routes import router
@@ -9,13 +11,13 @@ app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
 
 
-@app.get("/health")
+@app.get("/health")  # type: ignore[misc]
 async def health() -> dict[str, str]:
     """Return service liveness."""
     return {"status": "ok"}
 
 
-@app.get("/ready")
+@app.get("/ready")  # type: ignore[misc]
 async def ready() -> dict[str, str]:
     """Return service readiness."""
     return {"status": "ready"}

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -1,29 +1,35 @@
 """API routes including REST and tRPC-compatible endpoints."""
 
+from __future__ import annotations
+
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from sqlalchemy import select
 
-from .auth import verify_token
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from backend.shared.db import session_scope
+from backend.shared.db.models import Role, UserRole
+from .auth import require_role, verify_token
 
 router = APIRouter()
 
 
-@router.get("/status")
-async def status() -> Dict[str, str]:
+@router.get("/status")  # type: ignore[misc]
+async def status_endpoint() -> Dict[str, str]:
     """Public status endpoint."""
     return {"status": "ok"}
 
 
-@router.get("/protected")
+@router.get("/protected")  # type: ignore[misc]
 async def protected(
-    payload: Dict[str, Any] = Depends(verify_token),
+    payload: Dict[str, Any] = Depends(require_role("viewer")),
 ) -> Dict[str, Any]:
     """Protected endpoint requiring a valid token."""
     return {"user": payload.get("sub")}
 
 
-@router.post("/trpc/{procedure}")
+@router.post("/trpc/{procedure}")  # type: ignore[misc]
 async def trpc_endpoint(
     procedure: str,
     payload: Dict[str, Any] = Depends(verify_token),
@@ -32,3 +38,28 @@ async def trpc_endpoint(
     if procedure == "ping":
         return {"result": {"message": "pong", "user": payload.get("sub")}}
     return {"error": f"Procedure '{procedure}' not found"}
+
+
+@router.post("/roles/{user_id}")  # type: ignore[misc]
+async def assign_role(
+    user_id: str,
+    role: str,
+    _payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> Dict[str, str]:
+    """Assign a role to a user."""
+    with session_scope() as session:
+        role_obj = session.execute(
+            select(Role).where(Role.name == role)
+        ).scalar_one_or_none()
+        if role_obj is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+            )
+        existing = session.execute(
+            select(UserRole).where(UserRole.user_id == user_id)
+        ).scalar_one_or_none()
+        if existing:
+            existing.role_id = role_obj.id
+        else:
+            session.add(UserRole(user_id=user_id, role_id=role_obj.id))
+    return {"status": "assigned"}

--- a/backend/api-gateway/tests/test_auth.py
+++ b/backend/api-gateway/tests/test_auth.py
@@ -3,12 +3,12 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app
-from api_gateway.auth import create_access_token
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
 
 client = TestClient(app)
 
@@ -21,7 +21,7 @@ def test_protected_requires_token() -> None:
 
 def test_protected_accepts_valid_token() -> None:
     """Ensure protected route accepts valid token."""
-    token = create_access_token({"sub": "user1"})
+    token = create_access_token({"sub": "user1", "role": "viewer"})
     response = client.get(
         "/protected",
         headers={"Authorization": f"Bearer {token}"},

--- a/backend/api-gateway/tests/test_roles.py
+++ b/backend/api-gateway/tests/test_roles.py
@@ -1,0 +1,54 @@
+"""Tests for role-based access control."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+# Configure in-memory database before importing the app
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from backend.shared.db import engine, session_scope  # noqa: E402
+from backend.shared.db.base import Base  # noqa: E402
+from backend.shared.db.models import Role  # noqa: E402
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+
+Base.metadata.create_all(engine)
+with session_scope() as session:
+    session.add_all(
+        [Role(id=1, name="admin"), Role(id=2, name="editor"), Role(id=3, name="viewer")]
+    )
+
+client = TestClient(app)
+
+
+def test_protected_allows_viewer() -> None:
+    """Protected route should allow viewer role."""
+    token = create_access_token({"sub": "user1", "role": "viewer"})
+    resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_protected_rejects_editor() -> None:
+    """Protected route should reject role without viewer permission."""
+    token = create_access_token({"sub": "user1", "role": "editor"})
+    resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+def test_assign_role() -> None:
+    """Admin can assign role to a user."""
+    admin_token = create_access_token({"sub": "admin", "role": "admin"})
+    resp = client.post(
+        "/roles/user2",
+        params={"role": "editor"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "assigned"}

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -3,12 +3,12 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app
-from api_gateway.auth import create_access_token
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
 
 client = TestClient(app)
 
@@ -22,7 +22,7 @@ def test_status() -> None:
 
 def test_trpc_ping() -> None:
     """TRPC ping should return pong."""
-    token = create_access_token({"sub": "tester"})
+    token = create_access_token({"sub": "tester", "role": "viewer"})
     response = client.post(
         "/trpc/ping",
         headers={"Authorization": f"Bearer {token}"},

--- a/backend/shared/db/base.py
+++ b/backend/shared/db/base.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase
 
 
-class Base(DeclarativeBase):
+class Base(DeclarativeBase):  # type: ignore[misc]
     """Base class for all ORM models."""

--- a/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
@@ -1,0 +1,40 @@
+"""Create roles and user_roles tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create roles and user_roles tables with defaults."""
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=50), nullable=False, unique=True),
+    )
+    op.create_table(
+        "user_roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.String(length=100), nullable=False),
+        sa.Column("role_id", sa.Integer, sa.ForeignKey("roles.id"), nullable=False),
+    )
+    op.bulk_insert(
+        sa.table("roles", sa.column("id"), sa.column("name")),
+        [
+            {"id": 1, "name": "admin"},
+            {"id": 2, "name": "editor"},
+            {"id": 3, "name": "viewer"},
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Drop roles and user_roles tables."""
+    op.drop_table("user_roles")
+    op.drop_table("roles")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -89,3 +89,24 @@ class ABTest(Base):
     conversion_rate: Mapped[float] = mapped_column(Float, default=0.0)
 
     listing: Mapped[Listing] = relationship(back_populates="tests")
+
+
+class Role(Base):
+    """User role allowed to access the system."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True)
+
+
+class UserRole(Base):
+    """Mapping between a user ID and their assigned role."""
+
+    __tablename__ = "user_roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(100))
+    role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"))
+
+    role: Mapped[Role] = relationship()

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -23,4 +23,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]
+        FlaskInstrumentor().instrument_app(app)

--- a/frontend/admin-dashboard/__tests__/trpc.test.ts
+++ b/frontend/admin-dashboard/__tests__/trpc.test.ts
@@ -5,6 +5,9 @@ jest.mock('../src/trpc', () => ({
     ping: {
       mutate: jest.fn(),
     },
+    assignRole: {
+      mutate: jest.fn(),
+    },
   },
 }));
 
@@ -12,5 +15,13 @@ describe('tRPC ping', () => {
   it('calls trpc ping mutate', async () => {
     await trpc.ping.mutate();
     expect(trpc.ping.mutate).toHaveBeenCalled();
+  });
+
+  it('calls assignRole mutate', async () => {
+    await trpc.assignRole.mutate({ userId: 'u1', role: 'viewer' });
+    expect(trpc.assignRole.mutate).toHaveBeenCalledWith({
+      userId: 'u1',
+      role: 'viewer',
+    });
   });
 });

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -24,6 +24,9 @@ export default function AdminLayout({
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             {t('abTests')}
           </Link>
+          <Link href="/dashboard/roles" className="block hover:underline">
+            {t('roles')}
+          </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -7,5 +7,7 @@
   "signalStreamComingSoon": "Signal stream coming soon.",
   "galleryPlaceholder": "Gallery page placeholder.",
   "heatmapPlaceholder": "Heatmap page placeholder.",
-  "abTestsPlaceholder": "AB Tests page placeholder."
+  "abTestsPlaceholder": "AB Tests page placeholder.",
+  "roles": "Roles",
+  "rolesPlaceholder": "Assign roles to users."
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../../components/Button';
+import { trpc } from '../../trpc';
+
+export default function RolesPage() {
+  const { t } = useTranslation();
+  const [userId, setUserId] = useState('');
+  const [role, setRole] = useState('viewer');
+
+  async function assign() {
+    await trpc.assignRole.mutate({ userId, role });
+    setUserId('');
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{t('roles')}</h1>
+      <input
+        className="border p-2"
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+        placeholder="User ID"
+      />
+      <select
+        className="border p-2"
+        value={role}
+        onChange={(e) => setRole(e.target.value)}
+      >
+        <option value="admin">admin</option>
+        <option value="editor">editor</option>
+        <option value="viewer">viewer</option>
+      </select>
+      <Button onClick={assign}>{t('roles')}</Button>
+    </div>
+  );
+}

--- a/frontend/admin-dashboard/src/trpc.ts
+++ b/frontend/admin-dashboard/src/trpc.ts
@@ -3,12 +3,30 @@ export interface AppRouter {
     input: void;
     output: { message: string; user: string };
   };
+  assignRole: {
+    input: { userId: string; role: string };
+    output: { status: string };
+  };
 }
 
 export const trpc = {
   ping: {
     async mutate(): Promise<{ message: string; user: string }> {
       return { message: 'pong', user: 'admin' };
+    },
+  },
+  assignRole: {
+    async mutate({
+      userId,
+      role,
+    }: {
+      userId: string;
+      role: string;
+    }): Promise<{ status: string }> {
+      const res = await fetch(`/roles/${userId}?role=${role}`, {
+        method: 'POST',
+      });
+      return res.json();
     },
   },
 };


### PR DESCRIPTION
## Summary
- create `roles` table and default roles migration
- add role check helpers and update protected endpoints
- enable assigning roles via API Gateway
- expose role assignment in admin dashboard
- expand admin dashboard translations
- add unit tests for role-based access control

## Testing
- `flake8 backend/api-gateway/src/api_gateway/auth.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/models.py backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py backend/api-gateway/tests/test_roles.py backend/api-gateway/tests/test_auth.py backend/api-gateway/tests/test_routes.py`
- `mypy backend/api-gateway/src/api_gateway/auth.py backend/api-gateway/src/api_gateway/routes.py backend/shared/db/models.py backend/api-gateway/tests/test_roles.py backend/api-gateway/tests/test_auth.py backend/api-gateway/tests/test_routes.py backend/api-gateway/src/api_gateway/main.py backend/shared/db/base.py`
- `pydocstyle backend/api-gateway/src/api_gateway backend/shared/db backend/api-gateway/tests`
- `docformatter --in-place --recursive docs`
- `flake8 --select=D docs`
- `npm run lint:stylelint`
- `npm run lint:prettier` *(fails: Code style issues found in 10 files)*
- `npm run flow`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `sphinx-build -W -b html docs docs/_build` *(fails: build finished with problems, 19 warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_b_6877e7bed0808331a6694be6ada6fdb8