### PR TITLE
Add coverage thresholds and mocking docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,8 @@ jobs:
           python -m pip install -e .
       - name: Run tests
         run: |
-          pytest -W error -vv
+          pytest -vv
+          npm test
 
   publish:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to desAInz's documentation!
    blueprints/DesignIdeaEngineCompleteBlueprint
    admin_dashboard_trpc
    load_testing
+   mocking
    maintenance
    i18n
    security

--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -1,0 +1,40 @@
+# Mocking External Services
+
+Tests often need to run without real Kafka or Redis instances. Use lightweight mocks to simulate these dependencies.
+
+## Kafka
+
+`tests/test_kafka_utils.py` replaces the actual Kafka producer and consumer with dummy classes using `monkeypatch`.
+
+```python
+from backend.shared.kafka.utils import KafkaProducerWrapper
+
+class DummyProducer:
+    def __init__(self, *args, **kwargs):
+        self.sent = {}
+
+    def send(self, topic: str, value: dict) -> None:
+        self.sent[topic] = value
+
+    def flush(self) -> None:  # pragma: no cover
+        pass
+
+def test_producer(monkeypatch):
+    monkeypatch.setattr('backend.shared.kafka.utils.KafkaProducer', DummyProducer)
+    producer = KafkaProducerWrapper('kafka:9092', registry)
+    producer.produce('signals', {'id': '1'})
+    assert producer._producer.sent['signals'] == {'id': '1'}
+```
+
+## Redis
+
+`backend/scoring-engine/tests/test_cache.py` uses `fakeredis` to emulate Redis in memory.
+
+```python
+import fakeredis
+from scoring_engine.app import redis_client
+
+redis_client.connection_pool.connection_class = fakeredis.FakeConnection
+```
+
+With this setup, Redis operations run against an in-memory store without requiring a real server.

--- a/frontend/admin-dashboard/jest.config.js
+++ b/frontend/admin-dashboard/jest.config.js
@@ -3,6 +3,16 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'babel-jest',
   },
+  collectCoverage: true,
+  coverageDirectory: '<rootDir>/coverage',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -W error --cov=. --cov-report=term --cov-report=xml --cov-fail-under=80


### PR DESCRIPTION
## Summary
- enforce Python and JS coverage levels
- run npm tests in CI
- document mocking of Kafka and Redis

## Testing
- `black --check .`
- `flake8`
- `mypy backend/service-template`
- `npm run lint:eslint` *(fails: 'jest' is not defined)*
- `npm run lint:prettier` *(warnings only)*
- `npm run lint:stylelint`
- `npm run flow`
- `pytest -vv` *(fails: ModuleNotFoundError: No module named 'tests.test_scoring')*
- `npm test` *(fails: global coverage threshold not met)*
- `sphinx-build -b html -W -n docs docs/_build/html` *(fails: warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_b_6877ec7dbd9883319453a24f81ac13be