### PR TITLE
Add role-based access control

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -9,13 +9,13 @@ app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
 
 
-@app.get("/health")
+@app.get("/health")  # type: ignore[misc]
 async def health() -> dict[str, str]:
     """Return service liveness."""
     return {"status": "ok"}
 
 
-@app.get("/ready")
+@app.get("/ready")  # type: ignore[misc]
 async def ready() -> dict[str, str]:
     """Return service readiness."""
     return {"status": "ready"}

--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -2,33 +2,67 @@
 
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
 
-from .auth import verify_token
+from .auth import verify_token, require_role
+from backend.shared.db import session_scope
+from backend.shared.db.models import UserRole
 
 router = APIRouter()
 
 
-@router.get("/status")
-async def status() -> Dict[str, str]:
+@router.get("/status")  # type: ignore[misc]
+async def status_endpoint() -> Dict[str, str]:
     """Public status endpoint."""
     return {"status": "ok"}
 
 
-@router.get("/protected")
+@router.get("/roles")  # type: ignore[misc]
+async def list_roles(
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> list[Dict[str, str]]:
+    """Return all user role assignments."""
+    with session_scope() as session:
+        rows = session.execute(select(UserRole.username, UserRole.role)).all()
+    return [{"username": row.username, "role": row.role} for row in rows]
+
+
+@router.post("/roles/{username}")  # type: ignore[misc]
+async def assign_role(
+    username: str,
+    body: Dict[str, str],
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> Dict[str, str]:
+    """Assign ``role`` in ``body`` to ``username``."""
+    role = body.get("role")
+    if role not in {"admin", "editor", "viewer"}:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid role")
+    with session_scope() as session:
+        existing = session.execute(
+            select(UserRole).where(UserRole.username == username)
+        ).scalar_one_or_none()
+        if existing:
+            existing.role = role
+        else:
+            session.add(UserRole(username=username, role=role))
+    return {"username": username, "role": role}
+
+
+@router.get("/protected")  # type: ignore[misc]
 async def protected(
-    payload: Dict[str, Any] = Depends(verify_token),
+    payload: Dict[str, Any] = Depends(require_role("admin")),
 ) -> Dict[str, Any]:
-    """Protected endpoint requiring a valid token."""
+    """Protected endpoint requiring ``admin`` role."""
     return {"user": payload.get("sub")}
 
 
-@router.post("/trpc/{procedure}")
+@router.post("/trpc/{procedure}")  # type: ignore[misc]
 async def trpc_endpoint(
     procedure: str,
     payload: Dict[str, Any] = Depends(verify_token),
 ) -> Dict[str, Any]:
-    """tRPC-compatible endpoint."""
+    """TRPC-compatible endpoint."""
     if procedure == "ping":
         return {"result": {"message": "pong", "user": payload.get("sub")}}
     return {"error": f"Procedure '{procedure}' not found"}

--- a/backend/api-gateway/tests/test_auth.py
+++ b/backend/api-gateway/tests/test_auth.py
@@ -1,16 +1,30 @@
 """Tests for JWT auth middleware."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app
-from api_gateway.auth import create_access_token
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, engine, session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
 
 client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Create tables for tests."""
+    Base.metadata.create_all(engine)
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
 
 
 def test_protected_requires_token() -> None:
@@ -20,11 +34,23 @@ def test_protected_requires_token() -> None:
 
 
 def test_protected_accepts_valid_token() -> None:
-    """Ensure protected route accepts valid token."""
-    token = create_access_token({"sub": "user1"})
+    """Ensure protected route accepts valid admin token."""
+    token = create_access_token({"sub": "admin"})
     response = client.get(
         "/protected",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
-    assert response.json()["user"] == "user1"
+    assert response.json()["user"] == "admin"
+
+
+def test_protected_rejects_insufficient_role() -> None:
+    """Ensure protected route rejects users without admin role."""
+    with session_scope() as session:
+        session.add(UserRole(username="viewer", role="viewer"))
+    token = create_access_token({"sub": "viewer"})
+    resp = client.get(
+        "/protected",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403

--- a/backend/api-gateway/tests/test_health.py
+++ b/backend/api-gateway/tests/test_health.py
@@ -1,13 +1,13 @@
 """Tests for health and readiness endpoints."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app
+from api_gateway.main import app  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/api-gateway/tests/test_roles.py
+++ b/backend/api-gateway/tests/test_roles.py
@@ -1,0 +1,41 @@
+"""Tests for role management endpoints."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, engine, session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Create tables for the in-memory database."""
+    Base.metadata.create_all(engine)
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+def test_assign_and_list_roles() -> None:
+    """Assign a role and verify it is listed."""
+    token = create_access_token({"sub": "admin"})
+    resp = client.post(
+        "/roles/user1",
+        json={"role": "editor"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    resp = client.get("/roles", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert {"username": "user1", "role": "editor"} in resp.json()

--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -1,14 +1,14 @@
 """Tests for routing logic."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from api_gateway.main import app
-from api_gateway.auth import create_access_token
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/shared/db/base.py
+++ b/backend/shared/db/base.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase
 
 
-class Base(DeclarativeBase):
+class Base(DeclarativeBase):  # type: ignore[misc]
     """Base class for all ORM models."""

--- a/backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0001_placeholder.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from alembic import op
-import sqlalchemy as sa
 
 revision = "0001"
 down_revision = None

--- a/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0002_add_roles_table.py
@@ -1,0 +1,26 @@
+"""Add user_roles table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create user_roles table."""
+    op.create_table(
+        "user_roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("username", sa.String(length=50), nullable=False, unique=True),
+        sa.Column("role", sa.String(length=20), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop user_roles table."""
+    op.drop_table("user_roles")

--- a/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0003_merge_heads.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from alembic import op
-
 revision = "0003"
 down_revision = ("0002", "0002")
 branch_labels = None

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -118,3 +118,13 @@ class MarketplaceMetric(Base):
     revenue: Mapped[float] = mapped_column(Float, default=0.0)
 
     listing: Mapped[Listing] = relationship()
+
+
+class UserRole(Base):
+    """Association between a username and its role."""
+
+    __tablename__ = "user_roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    username: Mapped[str] = mapped_column(String(50), unique=True)
+    role: Mapped[str] = mapped_column(String(20))

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -23,4 +23,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]
+        FlaskInstrumentor().instrument_app(app)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Welcome to desAInz's documentation!
    maintenance
    i18n
    security
+   roles
 
 Kafka Utilities
 ---------------

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,9 @@
+# User Roles
+
+The API gateway enforces access control based on roles stored in the `user_roles` table. Three roles are available:
+
+- `admin`
+- `editor`
+- `viewer`
+
+Administrators can assign roles to users via the `/roles` API endpoint or the dashboard management page.

--- a/frontend/admin-dashboard/__tests__/navigation.test.tsx
+++ b/frontend/admin-dashboard/__tests__/navigation.test.tsx
@@ -26,3 +26,14 @@ test('navigates to Heatmap page when link clicked', async () => {
   await userEvent.click(screen.getByText('Heatmap'));
   expect(Router).toMatchObject({ pathname: '/dashboard/heatmap' });
 });
+
+test('navigates to Roles page when link clicked', async () => {
+  Router.setCurrentUrl('/dashboard');
+  renderWithRouter(
+    <AdminLayout>
+      <div>Home</div>
+    </AdminLayout>
+  );
+  await userEvent.click(screen.getByText('Roles'));
+  expect(Router).toMatchObject({ pathname: '/dashboard/roles' });
+});

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -24,6 +24,9 @@ export default function AdminLayout({
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             {t('abTests')}
           </Link>
+          <Link href="/dashboard/roles" className="block hover:underline">
+            {t('roles')}
+          </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -4,6 +4,7 @@
   "heatmap": "Heatmap",
   "gallery": "Gallery",
   "abTests": "AB Tests",
+  "roles": "Roles",
   "signalStreamComingSoon": "Signal stream coming soon.",
   "galleryPlaceholder": "Gallery page placeholder.",
   "heatmapPlaceholder": "Heatmap page placeholder.",

--- a/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Assignment {
+  username: string;
+  role: string;
+}
+
+export default function RolesPage() {
+  const { t } = useTranslation();
+  const [roles, setRoles] = useState<Assignment[]>([]);
+  useEffect(() => {
+    async function load() {
+      const resp = await fetch('/roles', {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+      });
+      if (resp.ok) {
+        setRoles(await resp.json());
+      }
+    }
+    void load();
+  }, []);
+  return (
+    <div>
+      <h1>{t('roles')}</h1>
+      <ul>
+        {roles.map((r) => (
+          <li key={r.username}>
+            {r.username}: {r.role}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `user_roles` table and migration
- enforce role claims in API Gateway
- expose role management endpoints
- add frontend page to display roles
- document roles feature
- include tests for protected routes and role management

## Testing
- `flake8 backend/api-gateway/src/api_gateway backend/api-gateway/tests backend/shared docs`
- `mypy backend/api-gateway/src/api_gateway backend/api-gateway/tests backend/shared/db`
- `npx eslint src/layouts/AdminLayout.tsx src/pages/dashboard/roles.tsx __tests__/navigation.test.tsx`
- `npx stylelint src/styles/*.css app/globals.css`
- `npm test --silent`
- `pytest` *(fails: 25 errors during collection)*
- `sphinx-build -b html docs/source docs/_build`

------
https://chatgpt.com/codex/tasks/task_b_6877eb95d6508331aa306da0456bb71a