### PR TITLE
Enable ISR, tree shaking for dashboard

### DIFF
--- a/frontend/admin-dashboard/README.md
+++ b/frontend/admin-dashboard/README.md
@@ -8,3 +8,9 @@ This is the frontend for the Admin Dashboard built with Next.js.
 npm install
 npm run dev
 ```
+
+## Build-time environment variables
+
+The dashboard reads its monitoring endpoint from `NEXT_PUBLIC_MONITORING_URL` at
+build time. During local development the variable can be left unset to fall back
+to `http://localhost:8000/status`.

--- a/frontend/admin-dashboard/next.config.ts
+++ b/frontend/admin-dashboard/next.config.ts
@@ -1,7 +1,23 @@
 import type { NextConfig } from 'next';
 
+/**
+ * Next.js configuration enabling tree shaking and aggressive code splitting.
+ * The `webpack` hook adjusts optimization settings while `esmExternals` allows
+ * packages published as ES modules to be tree shaken.
+ */
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    esmExternals: 'loose',
+  },
+  webpack(config) {
+    // Ensure unused exports are removed and common chunks are split automatically
+    config.optimization.usedExports = true;
+    config.optimization.splitChunks = {
+      ...config.optimization.splitChunks,
+      chunks: 'all',
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/ab-tests.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { useTranslation } from 'react-i18next';
-import { AbTestSummary } from '../../components/AbTestSummary';
+
+// Load the potentially heavy summary component lazily
+const AbTestSummary = dynamic(
+  () => import('../../components/AbTestSummary').then((m) => m.AbTestSummary),
+  { ssr: false, loading: () => <div>Loading...</div> }
+);
 
 export default function AbTestsPage() {
   const { t } = useTranslation();
@@ -10,4 +16,8 @@ export default function AbTestsPage() {
       <AbTestSummary abTestId={1} />
     </div>
   );
+}
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/gallery.tsx
@@ -5,3 +5,7 @@ export default function GalleryPage() {
   const { t } = useTranslation();
   return <div>{t('galleryPlaceholder')}</div>;
 }
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/heatmap.tsx
@@ -5,3 +5,7 @@ export default function HeatmapPage() {
   const { t } = useTranslation();
   return <div>{t('heatmapPlaceholder')}</div>;
 }
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/index.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/index.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { useTranslation } from 'react-i18next';
-import StatusIndicator from '../../components/StatusIndicator';
+
+// Dynamically import the status indicator to split the bundle
+const StatusIndicator = dynamic(
+  () => import('../../components/StatusIndicator'),
+  { ssr: false, loading: () => <div>Loading...</div> }
+);
 
 export default function DashboardPage() {
   const { t } = useTranslation();
@@ -10,4 +16,8 @@ export default function DashboardPage() {
       <div>{t('signalStreamComingSoon')}</div>
     </div>
   );
+}
+
+export async function getStaticProps() {
+  return { props: {}, revalidate: 60 };
 }


### PR DESCRIPTION
## Summary
- tweak Next.js build to use `esmExternals` and improved `splitChunks`
- lazy load dashboard modules and enable ISR
- document the `NEXT_PUBLIC_MONITORING_URL` variable

## Testing
- `npx eslint frontend/admin-dashboard/next.config.ts frontend/admin-dashboard/src/pages/dashboard/*.tsx --max-warnings=0`
- `npx prettier -c frontend/admin-dashboard/next.config.ts frontend/admin-dashboard/src/pages/dashboard/*.tsx frontend/admin-dashboard/README.md`
- `npx stylelint "frontend/admin-dashboard/**/*.css"`
- `npx flow check`
- `npm run test:frontend`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_6877ed7bb80c83319a1e8e83378fb414