### PR TITLE
Add maintenance cleanup orchestration

### DIFF
--- a/backend/api-gateway/tests/test_maintenance.py
+++ b/backend/api-gateway/tests/test_maintenance.py
@@ -1,0 +1,49 @@
+"""Tests for manual maintenance trigger."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, engine, session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
+from scripts import maintenance  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Prepare database tables."""
+    Base.metadata.create_all(engine)
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+def test_trigger_cleanup(monkeypatch) -> None:
+    """Manual trigger should invoke maintenance functions."""
+    called: dict[str, bool] = {}
+
+    def mark_archive() -> None:
+        called["archive"] = True
+
+    def mark_purge() -> None:
+        called["purge"] = True
+
+    monkeypatch.setattr(maintenance, "archive_old_mockups", mark_archive)
+    monkeypatch.setattr(maintenance, "purge_stale_records", mark_purge)
+    token = create_access_token({"sub": "admin"})
+    resp = client.post(
+        "/maintenance/cleanup",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert called == {"archive": True, "purge": True}

--- a/backend/orchestrator/orchestrator/ops.py
+++ b/backend/orchestrator/orchestrator/ops.py
@@ -6,6 +6,8 @@ import os
 
 from dagster import Failure, RetryPolicy, op
 
+from scripts import maintenance
+
 
 @op
 def ingest_signals(  # type: ignore[no-untyped-def]
@@ -73,4 +75,5 @@ def cleanup_data(  # type: ignore[no-untyped-def]
 ) -> None:
     """Remove temporary or stale data."""
     context.log.info("running cleanup")
-    # Placeholder for cleanup logic
+    maintenance.archive_old_mockups()
+    maintenance.purge_stale_records()

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -11,6 +11,10 @@ the following actions:
   are deleted along with log files under the directory specified by `LOG_DIR`.
 
 A scheduler is configured to run these tasks daily using `apscheduler`.
+The Dagster orchestrator exposes the same routines via the `cleanup_job`, which
+is scheduled hourly. Administrators can trigger the job manually from the Admin
+Dashboard.
+
 Run the script directly to start the scheduler:
 
 ```bash

--- a/frontend/admin-dashboard/__tests__/navigation.test.tsx
+++ b/frontend/admin-dashboard/__tests__/navigation.test.tsx
@@ -37,3 +37,14 @@ test('navigates to Roles page when link clicked', async () => {
   await userEvent.click(screen.getByText('Roles'));
   expect(Router).toMatchObject({ pathname: '/dashboard/roles' });
 });
+
+test('navigates to Maintenance page when link clicked', async () => {
+  Router.setCurrentUrl('/dashboard');
+  renderWithRouter(
+    <AdminLayout>
+      <div>Home</div>
+    </AdminLayout>
+  );
+  await userEvent.click(screen.getByText('Maintenance'));
+  expect(Router).toMatchObject({ pathname: '/dashboard/maintenance' });
+});

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -27,6 +27,9 @@ export default function AdminLayout({
           <Link href="/dashboard/roles" className="block hover:underline">
             {t('roles')}
           </Link>
+          <Link href="/dashboard/maintenance" className="block hover:underline">
+            {t('maintenance')}
+          </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -8,5 +8,9 @@
   "signalStreamComingSoon": "Signal stream coming soon.",
   "galleryPlaceholder": "Gallery page placeholder.",
   "heatmapPlaceholder": "Heatmap page placeholder.",
-  "abTestsPlaceholder": "AB Tests page placeholder."
+  "abTestsPlaceholder": "AB Tests page placeholder.",
+  "maintenance": "Maintenance",
+  "runCleanup": "Run Cleanup",
+  "cleanupTriggered": "Cleanup triggered",
+  "cleanupFailed": "Cleanup failed"
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../../components/Button';
+
+export default function MaintenancePage() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState('');
+
+  const runCleanup = async () => {
+    const resp = await fetch('/maintenance/cleanup', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+    });
+    if (resp.ok) {
+      setStatus(t('cleanupTriggered'));
+    } else {
+      setStatus(t('cleanupFailed'));
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={runCleanup}>{t('runCleanup')}</Button>
+      {status && <div>{status}</div>}
+    </div>
+  );
+}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts."""

--- a/scripts/maintenance.py
+++ b/scripts/maintenance.py
@@ -39,7 +39,11 @@ def purge_stale_records() -> None:
     """Delete signals and log files older than 30 days."""
     cutoff = datetime.utcnow() - timedelta(days=30)
     with session_scope() as session:
-        deleted = session.query(Signal).filter(Signal.timestamp < cutoff).delete(synchronize_session=False)
+        deleted = (
+            session.query(Signal)
+            .filter(Signal.timestamp < cutoff)
+            .delete(synchronize_session=False)
+        )
         logger.info("Deleted %s stale signals", deleted)
     if LOG_DIR.exists():
         for path in LOG_DIR.glob("*.log"):


### PR DESCRIPTION
## Summary
- integrate existing maintenance logic into Dagster ops
- add admin API endpoint and dashboard page to manually trigger cleanup
- document orchestration integration
- test manual trigger behaviour

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py backend/orchestrator/orchestrator/ops.py backend/api-gateway/tests/test_maintenance.py scripts/maintenance.py`
- `npx eslint frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx frontend/admin-dashboard/src/layouts/AdminLayout.tsx frontend/admin-dashboard/__tests__/navigation.test.tsx`
- `npm run lint:prettier`
- `npm run lint:stylelint`
- `npm run flow`
- `pytest backend/api-gateway/tests/test_maintenance.py backend/orchestrator/tests/test_jobs.py -W error` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_b_6877f36f32dc83318b0158f0c049148b