### PR TITLE
Add CSV export endpoints to analytics

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -2,16 +2,62 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Callable, Dict, Generator, cast
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from sqlalchemy import func
 
-from backend.shared.db import SessionLocal
+from jose import JWTError, jwt
+from sqlalchemy import select
+
+from backend.shared.db import SessionLocal, session_scope
 from backend.shared.db import models
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+
+SECRET_KEY = "change_this"
+ALGORITHM = "HS256"
+auth_scheme = HTTPBearer()
+
+
+def verify_token(
+    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
+) -> Dict[str, Any]:
+    """Verify JWT and return payload."""
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError as exc:  # pragma: no cover
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
+        ) from exc
+    return cast(Dict[str, Any], payload)
+
+
+def require_role(required_role: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Return dependency ensuring user has ``required_role``."""
+
+    def _checker(payload: Dict[str, Any] = Depends(verify_token)) -> Dict[str, Any]:
+        username = cast(str | None, payload.get("sub"))
+        if username is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
+            )
+        with session_scope() as session:
+            role = session.execute(
+                select(models.UserRole.role).where(models.UserRole.username == username)
+            ).scalar_one_or_none()
+        if role != required_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient role"
+            )
+        return payload
+
+    return _checker
+
 
 app = FastAPI(title="Analytics Service")
 configure_tracing(app, "analytics")
@@ -54,6 +100,33 @@ def ab_test_results(ab_test_id: int) -> ABTestSummary:
     )
 
 
+@app.get("/ab_test_results/{ab_test_id}/csv")  # type: ignore[misc]
+def ab_test_results_csv(
+    ab_test_id: int,
+    payload: Dict[str, Any] = Depends(require_role("editor")),
+) -> StreamingResponse:
+    """Return raw A/B test results as CSV."""
+    with SessionLocal() as session:
+        rows = (
+            session.query(
+                models.ABTestResult.timestamp,
+                models.ABTestResult.conversions,
+                models.ABTestResult.impressions,
+            )
+            .filter(models.ABTestResult.ab_test_id == ab_test_id)
+            .order_by(models.ABTestResult.timestamp)
+            .all()
+        )
+
+    def _generate() -> Generator[str, None, None]:
+        yield "timestamp,conversions,impressions\n"
+        for row in rows:
+            yield f"{row.timestamp.isoformat()},{row.conversions},{row.impressions}\n"
+
+    headers = {"Content-Disposition": "attachment; filename=ab_test_results.csv"}
+    return StreamingResponse(_generate(), media_type="text/csv", headers=headers)
+
+
 @app.get("/marketplace_metrics/{listing_id}")  # type: ignore[misc]
 def marketplace_metrics(listing_id: int) -> MarketplaceSummary:
     """Return aggregated metrics for a listing."""
@@ -73,6 +146,39 @@ def marketplace_metrics(listing_id: int) -> MarketplaceSummary:
         purchases=purchases,
         revenue=revenue,
     )
+
+
+@app.get("/marketplace_metrics/{listing_id}/csv")  # type: ignore[misc]
+def marketplace_metrics_csv(
+    listing_id: int,
+    payload: Dict[str, Any] = Depends(require_role("editor")),
+) -> StreamingResponse:
+    """Return raw marketplace metrics as CSV."""
+    with SessionLocal() as session:
+        rows = (
+            session.query(
+                models.MarketplaceMetric.timestamp,
+                models.MarketplaceMetric.clicks,
+                models.MarketplaceMetric.purchases,
+                models.MarketplaceMetric.revenue,
+            )
+            .filter(models.MarketplaceMetric.listing_id == listing_id)
+            .order_by(models.MarketplaceMetric.timestamp)
+            .all()
+        )
+
+    def _generate() -> Generator[str, None, None]:
+        yield "timestamp,clicks,purchases,revenue\n"
+        for row in rows:
+            yield (
+                f"{row.timestamp.isoformat()},"
+                f"{row.clicks},{row.purchases},{row.revenue}\n"
+            )
+
+    headers = {
+        "Content-Disposition": "attachment; filename=marketplace_metrics.csv",
+    }
+    return StreamingResponse(_generate(), media_type="text/csv", headers=headers)
 
 
 @app.get("/health")  # type: ignore[misc]

--- a/tests/integration/test_csv_exports.py
+++ b/tests/integration/test_csv_exports.py
@@ -1,0 +1,73 @@
+from __future__ import annotations  # noqa: D100
+
+"""Integration tests for CSV export endpoints."""  # noqa: D400
+
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+sys.path.append(
+    str(Path(__file__).resolve().parents[2] / "backend" / "api-gateway" / "src")
+)
+
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.analytics import api  # noqa: E402
+from backend.shared.db import Base, engine, SessionLocal  # noqa: E402
+from backend.shared.db.models import (  # noqa: E402
+    UserRole,
+    ABTest,
+    ABTestResult,
+    MarketplaceMetric,
+)
+
+
+def setup_module(module: object) -> None:
+    """Populate in-memory database with sample data."""
+    Base.metadata.create_all(engine)
+    with SessionLocal() as session:
+        session.add(UserRole(username="editor", role="editor"))
+        ab_test = ABTest(listing_id=1, variant="A", conversion_rate=0)
+        session.add(ab_test)
+        session.commit()
+        session.refresh(ab_test)
+        session.add_all(
+            [
+                ABTestResult(ab_test_id=ab_test.id, conversions=1, impressions=2),
+                ABTestResult(ab_test_id=ab_test.id, conversions=3, impressions=4),
+            ]
+        )
+        session.add(MarketplaceMetric(listing_id=1, clicks=5, purchases=1, revenue=9.0))
+        session.commit()
+
+
+def teardown_module(module: object) -> None:
+    """Clean up tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+client = TestClient(api.app)
+TOKEN = create_access_token({"sub": "editor"})
+
+
+def test_ab_test_csv_export() -> None:
+    """A/B test results CSV is returned with editor role."""
+    resp = client.get(
+        "/ab_test_results/1/csv",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    body = resp.text.strip().splitlines()
+    assert body[0] == "timestamp,conversions,impressions"
+    assert len(body) == 3
+
+
+def test_marketplace_csv_export() -> None:
+    """Marketplace metrics CSV is returned with editor role."""
+    resp = client.get(
+        "/marketplace_metrics/1/csv",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert resp.text.startswith("timestamp,clicks,purchases,revenue")


### PR DESCRIPTION
## Summary
- support CSV export for AB test results and marketplace metrics
- restrict the CSV routes to users with the `editor` role
- test CSV export endpoints

## Testing
- `flake8 backend/analytics/api.py tests/integration/test_csv_exports.py`
- `mypy backend/analytics/api.py tests/integration/test_csv_exports.py` *(fails: unused ignore comments in unrelated modules)*
- `npm run lint` *(fails: many eslint errors in existing files)*
- `npm run flow`
- `pytest tests/integration/test_csv_exports.py tests/test_analytics.py` *(fails: ModuleNotFoundError: No module named 'jose')*


------
https://chatgpt.com/codex/tasks/task_b_6877f91cf158833196dfa8113417f7ac