### PR TITLE
Add audit logging capabilities

### DIFF
--- a/backend/api-gateway/src/api_gateway/audit.py
+++ b/backend/api-gateway/src/api_gateway/audit.py
@@ -1,0 +1,24 @@
+"""Audit logging utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from backend.shared.db import session_scope
+from backend.shared.db.models import AuditLog
+
+
+def log_admin_action(
+    username: str, action: str, details: dict[str, Any] | None = None
+) -> None:
+    """Persist an admin action to the audit log."""
+    with session_scope() as session:
+        session.add(
+            AuditLog(
+                username=username,
+                action=action,
+                details=details,
+                timestamp=datetime.utcnow(),
+            )
+        )

--- a/backend/api-gateway/tests/test_audit_logs.py
+++ b/backend/api-gateway/tests/test_audit_logs.py
@@ -1,0 +1,42 @@
+"""Tests for audit log endpoint."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api_gateway.main import app  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+from backend.shared.db import Base, engine, session_scope  # noqa: E402
+from backend.shared.db.models import UserRole  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    """Create tables for tests."""
+    Base.metadata.create_all(engine)
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+
+
+def teardown_module(module: object) -> None:
+    """Drop tables after tests."""
+    Base.metadata.drop_all(engine)
+
+
+def test_audit_log_creation_and_query() -> None:
+    """Assign role and retrieve audit log entry."""
+    token = create_access_token({"sub": "admin"})
+    client.post(
+        "/roles/user2",
+        json={"role": "viewer"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    resp = client.get("/audit-logs", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+    assert any(item["action"] == "assign_role" for item in data["items"])

--- a/backend/shared/db/migrations/api_gateway/versions/0003_add_audit_log_table.py
+++ b/backend/shared/db/migrations/api_gateway/versions/0003_add_audit_log_table.py
@@ -1,0 +1,30 @@
+"""Add audit_logs table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create audit_logs table."""
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("username", sa.String(length=50), nullable=False),
+        sa.Column("action", sa.String(length=100), nullable=False),
+        sa.Column("details", sa.JSON(), nullable=True),
+        sa.Column(
+            "timestamp", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop audit_logs table."""
+    op.drop_table("audit_logs")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
+from typing import Any
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -128,3 +130,15 @@ class UserRole(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     username: Mapped[str] = mapped_column(String(50), unique=True)
     role: Mapped[str] = mapped_column(String(20))
+
+
+class AuditLog(Base):
+    """Record of privileged operations."""
+
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    username: Mapped[str] = mapped_column(String(50))
+    action: Mapped[str] = mapped_column(String(100))
+    details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -9,6 +9,8 @@ the following actions:
   are removed.
 - **Purge stale signals and logs**: any signal entries older than thirty days
   are deleted along with log files under the directory specified by `LOG_DIR`.
+- **Remove audit log entries**: records older than eighteen months are purged to
+  keep the audit table compact.
 
 A scheduler is configured to run these tasks daily using `apscheduler`.
 The Dagster orchestrator exposes the same routines via the `cleanup_job`, which


### PR DESCRIPTION
## Summary
- record admin actions in a new `audit_logs` table
- log admin actions for role management, cleanup trigger and protected endpoint
- expose `/audit-logs` endpoint with pagination
- purge audit log entries older than 18 months during maintenance
- document audit log retention
- regression test for audit logging

## Testing
- `flake8 backend/api-gateway/src/api_gateway/routes.py backend/shared/db/models.py scripts/maintenance.py backend/api-gateway/src/api_gateway/audit.py backend/api-gateway/tests/test_audit_logs.py`
- `mypy backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/src/api_gateway/audit.py backend/shared/db/models.py scripts/maintenance.py backend/api-gateway/tests/test_audit_logs.py` *(fails: unused ignore comments in unrelated files)*
- `pytest backend/api-gateway/tests/test_audit_logs.py` *(fails: coverage < 80%)*

------
https://chatgpt.com/codex/tasks/task_b_6877f93d43d8833183c055b8534babc6