### PR TITLE
Implement standard error responses

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -5,10 +5,12 @@ from fastapi import FastAPI
 from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 
 app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.get("/health")  # type: ignore[misc]

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -19,12 +19,14 @@ from .rules import load_rules, validate_mockup
 from .publisher import publish_with_retry
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 rate_limiter = MarketplaceRateLimiter(
     Redis.from_url(settings.redis_url),

--- a/backend/marketplace-publisher/tests/test_rate_limit.py
+++ b/backend/marketplace-publisher/tests/test_rate_limit.py
@@ -47,3 +47,6 @@ def test_rate_limit_exceeded(monkeypatch: Any, tmp_path: Path) -> None:
             },
         )
         assert resp2.status_code == 429
+        body = resp2.json()
+        assert body["error"] == "429"
+        assert "trace_id" in body

--- a/backend/marketplace-publisher/tests/test_validation.py
+++ b/backend/marketplace-publisher/tests/test_validation.py
@@ -38,4 +38,7 @@ def test_invalid_dimensions(monkeypatch: Any, tmp_path: Path) -> None:
             },
         )
         assert response.status_code == 400
-        assert "dimensions" in response.json()["detail"]
+        body = response.json()
+        assert body["error"] == "400"
+        assert "dimensions" in body["message"]
+        assert "trace_id" in body

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -20,6 +20,7 @@ from prometheus_client import (
 
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 from backend.shared.db import session_scope
 from backend.shared.db.models import Idea, Listing, Mockup, Signal
 from sqlalchemy import func, select
@@ -34,6 +35,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 REQUEST_COUNTER = Counter("http_requests_total", "Total HTTP requests")
 SIGNAL_TO_PUBLISH_SECONDS = Histogram(

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
@@ -16,6 +17,7 @@ from .storage import MetricsStore
 app = FastAPI(title="Optimization Service")
 configure_tracing(app, "optimization")
 add_profiling(app)
+add_exception_handlers(app)
 store = MetricsStore()
 
 

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -12,12 +12,14 @@ from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -2,5 +2,11 @@
 
 from .profiling import add_profiling
 from .tracing import configure_tracing
+from .errors import add_exception_handlers, ErrorResponse
 
-__all__ = ["add_profiling", "configure_tracing"]
+__all__ = [
+    "add_profiling",
+    "configure_tracing",
+    "add_exception_handlers",
+    "ErrorResponse",
+]

--- a/backend/shared/errors.py
+++ b/backend/shared/errors.py
@@ -1,0 +1,64 @@
+"""Common error handling utilities for FastAPI services."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from opentelemetry.trace import get_current_span
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response model."""
+
+    error: str
+    message: str
+    trace_id: str
+
+
+def _get_trace_id(request: Request) -> str:
+    """Return the current trace or correlation ID."""
+    span = get_current_span()
+    ctx = span.get_span_context()
+    if ctx.trace_id:
+        return format(ctx.trace_id, "032x")
+    return str(getattr(request.state, "correlation_id", "-"))
+
+
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle ``HTTPException`` and return a standardized response."""
+    assert isinstance(exc, HTTPException)
+    trace_id = _get_trace_id(request)
+    logger.warning(
+        "handled http exception",
+        extra={"trace_id": trace_id, "status_code": exc.status_code},
+    )
+    body = ErrorResponse(
+        error=str(exc.status_code),
+        message=str(exc.detail),
+        trace_id=trace_id,
+    )
+    return JSONResponse(status_code=exc.status_code, content=body.model_dump())
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle uncaught exceptions and return a standardized response."""
+    trace_id = _get_trace_id(request)
+    logger.error("unhandled exception", exc_info=exc, extra={"trace_id": trace_id})
+    body = ErrorResponse(
+        error="internal_server_error",
+        message="Internal Server Error",
+        trace_id=trace_id,
+    )
+    return JSONResponse(status_code=500, content=body.model_dump())
+
+
+def add_exception_handlers(app: FastAPI) -> None:
+    """Register common exception handlers on ``app``."""
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -16,12 +16,14 @@ from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.errors import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- add a shared error handler with structured logging
- apply error handlers across services
- assert error schema in publisher tests

## Testing
- `flake8 backend/shared/errors.py backend/shared/__init__.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/signal-ingestion/src/signal_ingestion/main.py backend/monitoring/src/monitoring/main.py backend/optimization/api.py backend/marketplace-publisher/tests/test_validation.py backend/marketplace-publisher/tests/test_rate_limit.py`
- `mypy --config-file /dev/null --ignore-missing-imports backend/shared/errors.py backend/shared/__init__.py backend/service-template/src/main.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/signal-ingestion/src/signal_ingestion/main.py backend/optimization/api.py backend/marketplace-publisher/tests/test_validation.py backend/marketplace-publisher/tests/test_rate_limit.py`
- `pytest backend/marketplace-publisher/tests/test_rate_limit.py::test_rate_limit_exceeded -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_6877f942132c833191f752f9e20124d0