### PR TITLE
Add autogenerated OpenAPI specs

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -8,6 +8,7 @@ from typing import Any
 import requests
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
+import os
 
 from .db import Marketplace
 
@@ -61,7 +62,10 @@ class SeleniumFallback:
         """Start a headless Firefox driver."""
         options = Options()
         options.add_argument("--headless")
-        self.driver = webdriver.Firefox(options=options)
+        if os.getenv("SELENIUM_SKIP") == "1":
+            self.driver = None
+        else:
+            self.driver = webdriver.Firefox(options=options)
 
     def publish(
         self, marketplace: Marketplace, design_path: Path, metadata: dict[str, Any]
@@ -72,6 +76,8 @@ class SeleniumFallback:
             Marketplace.amazon_merch: "https://merch.amazon.com/create",
             Marketplace.etsy: "https://www.etsy.com/new",
         }[marketplace]
+        if self.driver is None:
+            return
         self.driver.get(url)
         # This is a placeholder; real implementation would interact with the page.
         upload = self.driver.find_element("id", "upload")

--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -17,7 +17,9 @@ class PromptContext:
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
-TEMPLATE = Template("A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}")
+TEMPLATE = Template(
+    "A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}"
+)
 
 
 def build_prompt(context: PromptContext) -> str:

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -7,10 +7,34 @@ import os
 
 from flask import Flask, Response, jsonify, request
 import redis
+from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 
 from datetime import datetime
+
+
+class WeightsUpdate(BaseModel):
+    """Request payload for updating weight parameters."""
+
+    freshness: float
+    engagement: float
+    novelty: float
+    community_fit: float
+    seasonality: float
+
+
+class ScoreRequest(BaseModel):
+    """Request payload for scoring a signal."""
+
+    timestamp: datetime
+    engagement_rate: float
+    embedding: list[float]
+    metadata: dict[str, float] | None = None
+    centroid: list[float] | None = None
+    median_engagement: float | None = None
+    topics: list[str] | None = None
+
 
 from .scoring import Signal, calculate_score
 from .weight_repository import get_weights, update_weights
@@ -40,8 +64,8 @@ def read_weights() -> Response:
 @app.put("/weights")
 def update_weights_endpoint() -> Response:
     """Update weighting parameters via JSON payload."""
-    data = request.get_json(force=True)
-    weights = update_weights(**data)
+    body = WeightsUpdate(**request.get_json(force=True))
+    weights = update_weights(**body.model_dump())
     return jsonify(
         {
             "freshness": weights.freshness,
@@ -56,20 +80,20 @@ def update_weights_endpoint() -> Response:
 @app.post("/score")
 def score_signal() -> Response:
     """Score a signal and cache hot results."""
-    payload = request.get_json(force=True)
-    key = json.dumps(payload, sort_keys=True)
+    payload = ScoreRequest(**request.get_json(force=True))
+    key = json.dumps(payload.model_dump(), sort_keys=True)
     cached = redis_client.get(key)
     if cached is not None:
         return jsonify({"score": float(cached), "cached": True})
     signal = Signal(
-        timestamp=datetime.fromisoformat(payload["timestamp"]),
-        engagement_rate=float(payload["engagement_rate"]),
-        embedding=payload["embedding"],
-        metadata=payload.get("metadata", {}),
+        timestamp=payload.timestamp,
+        engagement_rate=payload.engagement_rate,
+        embedding=payload.embedding,
+        metadata=payload.metadata or {},
     )
-    centroid = payload.get("centroid", [0.0 for _ in payload["embedding"]])
-    median_engagement = float(payload.get("median_engagement", 0))
-    topics = payload.get("topics", [])
+    centroid = payload.centroid or [0.0 for _ in payload.embedding]
+    median_engagement = float(payload.median_engagement or 0)
+    topics = payload.topics or []
     score = calculate_score(signal, centroid, median_engagement, topics)
     redis_client.setex(key, 3600, score)
     return jsonify({"score": score, "cached": False})

--- a/backend/signal-ingestion/src/signal_ingestion/publisher.py
+++ b/backend/signal-ingestion/src/signal_ingestion/publisher.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 from kafka import KafkaProducer
+import os
 
-producer = KafkaProducer(
-    bootstrap_servers=["localhost:9092"], value_serializer=lambda v: v.encode()
-)
+if os.getenv("KAFKA_SKIP") == "1":  # pragma: no cover - used for docs generation
+    producer = None
+else:
+    producer = KafkaProducer(
+        bootstrap_servers=["localhost:9092"], value_serializer=lambda v: v.encode()
+    )
 
 
 def publish(topic: str, message: str) -> None:
     """Publish ``message`` to ``topic``."""
+    if producer is None:
+        return
     producer.send(topic, message)
     producer.flush()

--- a/docs/api/backend.analytics.rst
+++ b/docs/api/backend.analytics.rst
@@ -1,7 +1,18 @@
-backend.analytics module
-========================
+backend.analytics package
+=========================
+
+.. automodule:: backend.analytics
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.analytics.api module
+----------------------------
 
 .. automodule:: backend.analytics.api
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.rst
+++ b/docs/api/backend.rst
@@ -12,5 +12,6 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
-   backend.optimization
    backend.analytics
+   backend.optimization
+   backend.shared

--- a/docs/api/backend.shared.db.rst
+++ b/docs/api/backend.shared.db.rst
@@ -1,0 +1,26 @@
+backend.shared.db package
+=========================
+
+.. automodule:: backend.shared.db
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.shared.db.base module
+-----------------------------
+
+.. automodule:: backend.shared.db.base
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.shared.db.models module
+-------------------------------
+
+.. automodule:: backend.shared.db.models
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.shared.kafka.rst
+++ b/docs/api/backend.shared.kafka.rst
@@ -1,0 +1,26 @@
+backend.shared.kafka package
+============================
+
+.. automodule:: backend.shared.kafka
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Submodules
+----------
+
+backend.shared.kafka.schema\_registry module
+--------------------------------------------
+
+.. automodule:: backend.shared.kafka.schema_registry
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.shared.kafka.utils module
+---------------------------------
+
+.. automodule:: backend.shared.kafka.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/backend.shared.rst
+++ b/docs/api/backend.shared.rst
@@ -1,0 +1,35 @@
+backend.shared package
+======================
+
+.. automodule:: backend.shared
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   backend.shared.db
+   backend.shared.kafka
+
+Submodules
+----------
+
+backend.shared.profiling module
+-------------------------------
+
+.. automodule:: backend.shared.profiling
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+backend.shared.tracing module
+-----------------------------
+
+.. automodule:: backend.shared.tracing
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.openapi",
 ]
 
 autosummary_generate = True
@@ -102,7 +103,20 @@ def _run_apidoc(app: "Sphinx") -> None:
     )
 
 
+def _generate_openapi(app: "Sphinx") -> None:
+    """Generate OpenAPI specifications for all services."""
+    root = os.path.abspath(os.path.join(app.srcdir, ".."))
+    env = os.environ.copy()
+    env["KAFKA_SKIP"] = "1"
+    env["SELENIUM_SKIP"] = "1"
+    subprocess.check_call(
+        [sys.executable, os.path.join(root, "scripts", "generate_openapi.py")],
+        env=env,
+    )
+
+
 def setup(app: "Sphinx") -> None:
     """Set up Sphinx hooks."""
     app.connect("builder-inited", _run_linters)
     app.connect("builder-inited", _run_apidoc)
+    app.connect("builder-inited", _generate_openapi)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Welcome to desAInz's documentation!
    security
    roles
    daily_summary
+   openapi_specs
 
 Kafka Utilities
 ---------------

--- a/docs/openapi/analytics.rst
+++ b/docs/openapi/analytics.rst
@@ -1,0 +1,5 @@
+Analytics API
+===========================
+
+.. openapi:: ../../openapi/analytics.json
+   :encoding: utf-8

--- a/docs/openapi/api-gateway.rst
+++ b/docs/openapi/api-gateway.rst
@@ -1,0 +1,5 @@
+Api Gateway API
+===========================
+
+.. openapi:: ../../openapi/api-gateway.json
+   :encoding: utf-8

--- a/docs/openapi/marketplace-publisher.rst
+++ b/docs/openapi/marketplace-publisher.rst
@@ -1,0 +1,5 @@
+Marketplace Publisher API
+===========================
+
+.. openapi:: ../../openapi/marketplace-publisher.json
+   :encoding: utf-8

--- a/docs/openapi/monitoring.rst
+++ b/docs/openapi/monitoring.rst
@@ -1,0 +1,5 @@
+Monitoring API
+===========================
+
+.. openapi:: ../../openapi/monitoring.json
+   :encoding: utf-8

--- a/docs/openapi/optimization.rst
+++ b/docs/openapi/optimization.rst
@@ -1,0 +1,5 @@
+Optimization API
+===========================
+
+.. openapi:: ../../openapi/optimization.json
+   :encoding: utf-8

--- a/docs/openapi/scoring-engine.rst
+++ b/docs/openapi/scoring-engine.rst
@@ -1,0 +1,5 @@
+Scoring Engine API
+===========================
+
+.. openapi:: ../../openapi/scoring-engine.json
+   :encoding: utf-8

--- a/docs/openapi/signal-ingestion.rst
+++ b/docs/openapi/signal-ingestion.rst
@@ -1,0 +1,5 @@
+Signal Ingestion API
+===========================
+
+.. openapi:: ../../openapi/signal-ingestion.json
+   :encoding: utf-8

--- a/docs/openapi_specs.rst
+++ b/docs/openapi_specs.rst
@@ -1,0 +1,16 @@
+OpenAPI Specifications
+======================
+
+The following specifications describe each microservice's HTTP API. They are
+automatically generated using ``scripts/generate_openapi.py``.
+
+.. toctree::
+   :maxdepth: 1
+
+   openapi/api-gateway
+   openapi/analytics
+   openapi/marketplace-publisher
+   openapi/monitoring
+   openapi/optimization
+   openapi/scoring-engine
+   openapi/signal-ingestion

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Performance Profiling
 
 Recent profiling efforts added a lightweight middleware which logs request durations for all backend services. Both FastAPI and Flask applications now call `add_profiling` during startup. The middleware records timing for each request using `time.perf_counter` and writes the result to the service log.

--- a/docs/scoring_engine/index.rst
+++ b/docs/scoring_engine/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. Scoring Engine documentation master file, created by
    sphinx-quickstart on Wed Jul 16 15:06:25 2025.
    You can adapt this file completely to your liking, but it should at least

--- a/openapi/analytics.json
+++ b/openapi/analytics.json
@@ -1,0 +1,238 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Analytics Service",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/ab_test_results/{ab_test_id}": {
+      "get": {
+        "summary": "Ab Test Results",
+        "description": "Return aggregated A/B test results.",
+        "operationId": "ab_test_results_ab_test_results__ab_test_id__get",
+        "parameters": [
+          {
+            "name": "ab_test_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ab Test Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ABTestSummary"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/marketplace_metrics/{listing_id}": {
+      "get": {
+        "summary": "Marketplace Metrics",
+        "description": "Return aggregated metrics for a listing.",
+        "operationId": "marketplace_metrics_marketplace_metrics__listing_id__get",
+        "parameters": [
+          {
+            "name": "listing_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Listing Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketplaceSummary"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ABTestSummary": {
+        "properties": {
+          "ab_test_id": {
+            "type": "integer",
+            "title": "Ab Test Id"
+          },
+          "conversions": {
+            "type": "integer",
+            "title": "Conversions"
+          },
+          "impressions": {
+            "type": "integer",
+            "title": "Impressions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ab_test_id",
+          "conversions",
+          "impressions"
+        ],
+        "title": "ABTestSummary",
+        "description": "Summary of results for an A/B test."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MarketplaceSummary": {
+        "properties": {
+          "listing_id": {
+            "type": "integer",
+            "title": "Listing Id"
+          },
+          "clicks": {
+            "type": "integer",
+            "title": "Clicks"
+          },
+          "purchases": {
+            "type": "integer",
+            "title": "Purchases"
+          },
+          "revenue": {
+            "type": "number",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "listing_id",
+          "clicks",
+          "purchases",
+          "revenue"
+        ],
+        "title": "MarketplaceSummary",
+        "description": "Aggregated metrics for a listing."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/openapi/api-gateway.json
+++ b/openapi/api-gateway.json
@@ -1,0 +1,329 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "API Gateway",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Status Endpoint",
+        "description": "Public status endpoint.",
+        "operationId": "status_endpoint_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Status Endpoint Status Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles": {
+      "get": {
+        "summary": "List Roles",
+        "description": "Return all user role assignments.",
+        "operationId": "list_roles_roles_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "type": "array",
+                  "title": "Response List Roles Roles Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/roles/{username}": {
+      "post": {
+        "summary": "Assign Role",
+        "description": "Assign ``role`` in ``body`` to ``username``.",
+        "operationId": "assign_role_roles__username__post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Assign Role Roles  Username  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/protected": {
+      "get": {
+        "summary": "Protected",
+        "description": "Protected endpoint requiring ``admin`` role.",
+        "operationId": "protected_protected_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Protected Protected Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/maintenance/cleanup": {
+      "post": {
+        "summary": "Trigger Cleanup",
+        "description": "Run cleanup tasks immediately.",
+        "operationId": "trigger_cleanup_maintenance_cleanup_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Trigger Cleanup Maintenance Cleanup Post"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/trpc/{procedure}": {
+      "post": {
+        "summary": "Trpc Endpoint",
+        "description": "TRPC-compatible endpoint.",
+        "operationId": "trpc_endpoint_trpc__procedure__post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "procedure",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Procedure"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Trpc Endpoint Trpc  Procedure  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/openapi/marketplace-publisher.json
+++ b/openapi/marketplace-publisher.json
@@ -1,0 +1,225 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "marketplace-publisher",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/publish": {
+      "post": {
+        "summary": "Publish",
+        "description": "Create a publish task and run it in the background.",
+        "operationId": "publish_publish_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object",
+                  "title": "Response Publish Publish Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/progress/{task_id}": {
+      "get": {
+        "summary": "Progress",
+        "description": "Return current status of a publish task.",
+        "operationId": "progress_progress__task_id__get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Progress Progress  Task Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Marketplace": {
+        "type": "string",
+        "enum": [
+          "redbubble",
+          "amazon_merch",
+          "etsy"
+        ],
+        "title": "Marketplace",
+        "description": "Supported marketplaces."
+      },
+      "PublishRequest": {
+        "properties": {
+          "marketplace": {
+            "$ref": "#/components/schemas/Marketplace"
+          },
+          "design_path": {
+            "type": "string",
+            "format": "path",
+            "title": "Design Path"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": [
+          "marketplace",
+          "design_path"
+        ],
+        "title": "PublishRequest",
+        "description": "Request body for initiating a publish task."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/openapi/monitoring.json
+++ b/openapi/monitoring.json
@@ -1,0 +1,210 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "monitoring",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "description": "Expose Prometheus metrics.",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/overview": {
+      "get": {
+        "summary": "Overview",
+        "description": "Return basic system information.",
+        "operationId": "overview_overview_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "type": "object",
+                  "title": "Response Overview Overview Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics": {
+      "get": {
+        "summary": "Analytics",
+        "description": "Return placeholder analytics dashboard data.",
+        "operationId": "analytics_analytics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object",
+                  "title": "Response Analytics Analytics Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Status",
+        "description": "Return health status for core services.",
+        "operationId": "status_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Status Status Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sla": {
+      "get": {
+        "summary": "Sla",
+        "description": "Check SLA status and emit PagerDuty alert if violated.",
+        "operationId": "sla_sla_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "type": "object",
+                  "title": "Response Sla Sla Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/latency": {
+      "get": {
+        "summary": "Latency",
+        "description": "Return average signal-to-publish latency without triggering alerts.",
+        "operationId": "latency_latency_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "type": "object",
+                  "title": "Response Latency Latency Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/logs": {
+      "get": {
+        "summary": "Logs",
+        "description": "Return the latest application logs.",
+        "operationId": "logs_logs_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Logs Logs Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/optimization.json
+++ b/openapi/optimization.json
@@ -1,0 +1,196 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Optimization Service",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/metrics": {
+      "post": {
+        "summary": "Add Metric",
+        "description": "Store a new resource metric.",
+        "operationId": "add_metric_metrics_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetricIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Add Metric Metrics Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/optimizations": {
+      "get": {
+        "summary": "Get Optimizations",
+        "description": "Return recommended cost optimizations.",
+        "operationId": "get_optimizations_optimizations_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Get Optimizations Optimizations Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MetricIn": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "cpu_percent": {
+            "type": "number",
+            "title": "Cpu Percent"
+          },
+          "memory_mb": {
+            "type": "number",
+            "title": "Memory Mb"
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp",
+          "cpu_percent",
+          "memory_mb"
+        ],
+        "title": "MetricIn",
+        "description": "Request body for submitting a resource metric."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/openapi/scoring-engine.json
+++ b/openapi/scoring-engine.json
@@ -1,0 +1,195 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Scoring Engine",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/weights": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WeightsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/score": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Ready"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "WeightsUpdate": {
+        "description": "Request payload for updating weight parameters.",
+        "properties": {
+          "freshness": {
+            "title": "Freshness",
+            "type": "number"
+          },
+          "engagement": {
+            "title": "Engagement",
+            "type": "number"
+          },
+          "novelty": {
+            "title": "Novelty",
+            "type": "number"
+          },
+          "community_fit": {
+            "title": "Community Fit",
+            "type": "number"
+          },
+          "seasonality": {
+            "title": "Seasonality",
+            "type": "number"
+          }
+        },
+        "required": [
+          "freshness",
+          "engagement",
+          "novelty",
+          "community_fit",
+          "seasonality"
+        ],
+        "title": "WeightsUpdate",
+        "type": "object"
+      },
+      "ScoreRequest": {
+        "description": "Request payload for scoring a signal.",
+        "properties": {
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "engagement_rate": {
+            "title": "Engagement Rate",
+            "type": "number"
+          },
+          "embedding": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Embedding",
+            "type": "array"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Metadata"
+          },
+          "centroid": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Centroid"
+          },
+          "median_engagement": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Median Engagement"
+          },
+          "topics": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Topics"
+          }
+        },
+        "required": [
+          "timestamp",
+          "engagement_rate",
+          "embedding"
+        ],
+        "title": "ScoreRequest",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/openapi/signal-ingestion.json
+++ b/openapi/signal-ingestion.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "signal-ingestion",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service liveness.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Return service readiness.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingest": {
+      "post": {
+        "summary": "Ingest Signals",
+        "description": "Trigger signal ingestion.",
+        "operationId": "ingest_signals_ingest_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Ingest Signals Ingest Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ aiosqlite
 locust
 
 pip-audit
+sphinxcontrib-openapi

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate OpenAPI specs for microservices."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVICES = {
+    "analytics": {"module": "backend.analytics.api", "app": "app"},
+    "optimization": {"module": "backend.optimization.api", "app": "app"},
+    "signal-ingestion": {
+        "module": "signal_ingestion.main",
+        "app": "app",
+        "path": PROJECT_ROOT / "backend" / "signal-ingestion" / "src",
+    },
+    "marketplace-publisher": {
+        "module": "marketplace_publisher.main",
+        "app": "app",
+        "path": PROJECT_ROOT / "backend" / "marketplace-publisher" / "src",
+    },
+    "monitoring": {
+        "module": "monitoring.main",
+        "app": "app",
+        "path": PROJECT_ROOT / "backend" / "monitoring" / "src",
+    },
+    "api-gateway": {
+        "module": "api_gateway.main",
+        "app": "app",
+        "path": PROJECT_ROOT / "backend" / "api-gateway" / "src",
+    },
+}
+
+OPENAPI_DIR = PROJECT_ROOT / "openapi"
+OPENAPI_DIR.mkdir(exist_ok=True)
+
+for name, spec in SERVICES.items():
+    extra_path = spec.get("path")
+    if extra_path:
+        sys.path.insert(0, str(extra_path))
+    module_name = spec["module"]
+    if module_name == "main":
+        module_path = extra_path / "main.py" if extra_path else Path("main.py")
+        spec_obj = importlib.util.spec_from_file_location(
+            "service_template_main", module_path
+        )
+        module = importlib.util.module_from_spec(spec_obj)
+        assert spec_obj.loader is not None
+        spec_obj.loader.exec_module(module)
+    else:
+        module = importlib.import_module(module_name)
+    app = getattr(module, spec["app"])
+    if hasattr(app, "openapi"):
+        data = app.openapi()
+    else:
+        continue
+    path = OPENAPI_DIR / f"{name}.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+# scoring-engine manual spec
+sys.path.insert(0, str(PROJECT_ROOT / "backend" / "scoring-engine"))
+try:
+    from scoring_engine.app import ScoreRequest, WeightsUpdate
+except Exception as exc:  # pragma: no cover - runtime import guard
+    raise SystemExit(f"Failed importing scoring_engine: {exc}")
+
+spec = {
+    "openapi": "3.0.2",
+    "info": {"title": "Scoring Engine", "version": "1.0.0"},
+    "paths": {
+        "/weights": {
+            "get": {"responses": {"200": {"description": "OK"}}},
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/WeightsUpdate"}
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {"200": {"description": "OK"}},
+            },
+        },
+        "/score": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/ScoreRequest"}
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {"200": {"description": "OK"}},
+            }
+        },
+        "/health": {"get": {"responses": {"200": {"description": "OK"}}}},
+        "/ready": {"get": {"responses": {"200": {"description": "Ready"}}}},
+    },
+    "components": {
+        "schemas": {
+            "WeightsUpdate": WeightsUpdate.model_json_schema(),
+            "ScoreRequest": ScoreRequest.model_json_schema(),
+        }
+    },
+}
+(OPENAPI_DIR / "scoring-engine.json").write_text(
+    json.dumps(spec, indent=2), encoding="utf-8"
+)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup, find_packages
 
-setup(name='desAInz', version='0.1', packages=find_packages())
+setup(name="desAInz", version="0.1", packages=find_packages())


### PR DESCRIPTION
## Summary
- export OpenAPI schemas for each FastAPI and Flask service
- provide docs for every API spec using sphinxcontrib-openapi
- skip external integrations when generating docs
- add request models in scoring engine
- avoid side effects in publisher implementations

## Testing
- `flake8`
- `black --check .`
- `mypy backend`
- `docformatter --in-place --recursive docs`
- `pydocstyle docs`
- `sphinx-build -b html -W -T docs docs/_build/html`
- `pytest -W error` *(fails: ModuleNotFoundError for several test modules)*

------
https://chatgpt.com/codex/tasks/task_b_6877f9009d848331a23061ad1a2337e0