### PR TITLE
Implement consistent error schema

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -15,6 +15,7 @@ from backend.shared.db import models
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
+from backend.shared.error_handling import add_exception_handlers
 
 
 configure_logging()
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="Analytics Service")
 configure_tracing(app, "analytics")
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -10,6 +10,7 @@ from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
+from backend.shared.error_handling import add_exception_handlers
 
 
 configure_logging()
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="API Gateway")
 configure_tracing(app, "api-gateway")
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -19,12 +19,14 @@ from .rules import load_rules, validate_mockup
 from .publisher import publish_with_retry
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.error_handling import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 rate_limiter = MarketplaceRateLimiter(
     Redis.from_url(settings.redis_url),

--- a/backend/monitoring/src/monitoring/main.py
+++ b/backend/monitoring/src/monitoring/main.py
@@ -20,6 +20,7 @@ from prometheus_client import (
 
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.error_handling import add_exception_handlers
 from backend.shared.db import session_scope
 from backend.shared.db.models import Idea, Listing, Mockup, Signal
 from sqlalchemy import func, select
@@ -34,6 +35,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 REQUEST_COUNTER = Counter("http_requests_total", "Total HTTP requests")
 SIGNAL_TO_PUBLISH_SECONDS = Histogram(

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
+from backend.shared.error_handling import add_exception_handlers
 from .metrics import MetricsAnalyzer, ResourceMetric
 from .storage import MetricsStore
 
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="Optimization Service")
 configure_tracing(app, "optimization")
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -14,9 +14,14 @@ from pydantic import BaseModel
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
+from backend.shared.error_handling import add_exception_handlers
+from .scoring import Signal, calculate_score
+from .weight_repository import get_weights, update_weights
 
 
 from datetime import datetime
+
+configure_logging()
 
 
 class WeightsUpdate(BaseModel):
@@ -41,16 +46,12 @@ class ScoreRequest(BaseModel):
     topics: list[str] | None = None
 
 
-from .scoring import Signal, calculate_score
-from .weight_repository import get_weights, update_weights
-
-
-configure_logging()
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 configure_tracing(app, "scoring-engine")
 add_profiling(app)
+add_exception_handlers(app)
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 redis_client = redis.Redis.from_url(REDIS_URL)
 

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -12,12 +12,14 @@ from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.error_handling import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.middleware("http")

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -3,5 +3,12 @@
 from .profiling import add_profiling
 from .tracing import configure_tracing
 from .logging import configure_logging
+from .error_handling import ErrorResponse, add_exception_handlers
 
-__all__ = ["add_profiling", "configure_tracing", "configure_logging"]
+__all__ = [
+    "add_profiling",
+    "configure_tracing",
+    "configure_logging",
+    "ErrorResponse",
+    "add_exception_handlers",
+]

--- a/backend/shared/error_handling.py
+++ b/backend/shared/error_handling.py
@@ -1,0 +1,113 @@
+"""Exception handling utilities for services."""
+
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import HTTPException as FlaskHTTPException
+from opentelemetry import trace
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorResponse(BaseModel):
+    """Schema for API error responses."""
+
+    detail: str
+    correlation_id: str
+    trace_id: str | None = None
+
+
+def _get_trace_id() -> str | None:
+    span = trace.get_current_span()
+    if span is not None:
+        ctx = span.get_span_context()
+        if ctx.trace_id:
+            return f"{ctx.trace_id:032x}"
+    return None
+
+
+def _fastapi_http_exception_handler(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    correlation_id = getattr(request.state, "correlation_id", "-")
+    trace_id = _get_trace_id()
+    logger.warning(
+        "http error",
+        extra={
+            "correlation_id": correlation_id,
+            "trace_id": trace_id,
+            "status_code": exc.status_code,
+        },
+    )
+    body = ErrorResponse(
+        detail=str(exc.detail), correlation_id=correlation_id, trace_id=trace_id
+    )
+    return JSONResponse(status_code=exc.status_code, content=body.model_dump())
+
+
+async def _fastapi_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    correlation_id = getattr(request.state, "correlation_id", "-")
+    trace_id = _get_trace_id()
+    logger.exception(
+        "unhandled exception",
+        exc_info=exc,
+        extra={"correlation_id": correlation_id, "trace_id": trace_id},
+    )
+    body = ErrorResponse(
+        detail="Internal Server Error", correlation_id=correlation_id, trace_id=trace_id
+    )
+    return JSONResponse(status_code=500, content=body.model_dump())
+
+
+def _flask_http_exception_handler(exc: FlaskHTTPException) -> Any:
+    correlation_id = getattr(request, "correlation_id", "-")
+    trace_id = _get_trace_id()
+    logger.warning(
+        "http error",
+        extra={
+            "correlation_id": correlation_id,
+            "trace_id": trace_id,
+            "status_code": exc.code,
+        },
+    )
+    body = ErrorResponse(
+        detail=str(exc.description), correlation_id=correlation_id, trace_id=trace_id
+    )
+    response = jsonify(body.model_dump())
+    response.status_code = int(exc.code or 500)
+    return response
+
+
+def _flask_exception_handler(exc: Exception) -> Any:
+    correlation_id = getattr(request, "correlation_id", "-")
+    trace_id = _get_trace_id()
+    logger.exception(
+        "unhandled exception",
+        exc_info=exc,
+        extra={"correlation_id": correlation_id, "trace_id": trace_id},
+    )
+    body = ErrorResponse(
+        detail="Internal Server Error", correlation_id=correlation_id, trace_id=trace_id
+    )
+    response = jsonify(body.model_dump())
+    response.status_code = 500
+    return response
+
+
+def add_exception_handlers(app: FastAPI | Flask) -> None:
+    """Attach standardized exception handlers to ``app``."""
+    if isinstance(app, FastAPI):
+        app.add_exception_handler(HTTPException, _fastapi_http_exception_handler)
+        app.add_exception_handler(Exception, _fastapi_exception_handler)
+    else:
+        app.register_error_handler(FlaskHTTPException, _flask_http_exception_handler)
+        app.register_error_handler(Exception, _flask_exception_handler)

--- a/backend/signal-ingestion/src/signal_ingestion/main.py
+++ b/backend/signal-ingestion/src/signal_ingestion/main.py
@@ -16,12 +16,14 @@ from .logging_config import configure_logging
 from .settings import settings
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
+from backend.shared.error_handling import add_exception_handlers
 
 configure_logging()
 logger = logging.getLogger(__name__)
 app = FastAPI(title=settings.app_name)
 configure_tracing(app, settings.app_name)
 add_profiling(app)
+add_exception_handlers(app)
 
 
 @app.on_event("startup")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,65 @@
+# flake8: noqa
+"""Tests for standardized error handling utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from flask import Flask, abort
+
+from backend.shared.error_handling import add_exception_handlers
+
+
+def test_fastapi_error_response_schema() -> None:
+    """Ensure FastAPI apps return standardized error responses."""
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.get("/fail")
+    async def fail() -> None:
+        raise HTTPException(status_code=400, detail="bad")
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/fail")
+    body = resp.json()
+    assert resp.status_code == 400
+    assert set(body) == {"detail", "correlation_id", "trace_id"}
+
+    resp = client.get("/boom")
+    body = resp.json()
+    assert resp.status_code == 500
+    assert body["detail"] == "Internal Server Error"
+
+
+def test_flask_error_response_schema() -> None:
+    """Ensure Flask apps return standardized error responses."""
+    app = Flask(__name__)
+    add_exception_handlers(app)
+
+    @app.route("/fail")
+    def fail() -> None:  # type: ignore[return-value]
+        abort(400, description="bad")
+
+    @app.route("/boom")
+    def boom() -> None:  # type: ignore[return-value]
+        raise RuntimeError("boom")
+
+    client = app.test_client()
+
+    resp = client.get("/fail")
+    body = resp.get_json()
+    assert resp.status_code == 400
+    assert set(body) == {"detail", "correlation_id", "trace_id"}
+
+    resp = client.get("/boom")
+    body = resp.get_json()
+    assert resp.status_code == 500
+    assert body["detail"] == "Internal Server Error"


### PR DESCRIPTION
## Summary
- centralize exception handlers in shared module
- use structured ErrorResponse across services
- add missing exports for new utilities
- ensure all apps register the handlers
- test FastAPI and Flask error responses

## Testing
- `pytest -o addopts='' -p no:cov -W error tests/test_error_handling.py`

------
https://chatgpt.com/codex/tasks/task_b_6877feaf7f40833195fa49c2fffa477c