### PR TITLE
Add Slack alerts and feedback analysis

### DIFF
--- a/backend/feedback-loop/feedback_loop/__init__.py
+++ b/backend/feedback-loop/feedback_loop/__init__.py
@@ -4,6 +4,7 @@ from .ab_testing import ABTestManager, BudgetAllocation
 from .scheduler import setup_scheduler
 from .weight_updater import update_weights
 from .ingestion import ingest_metrics
+from .highlighting import highlight_low_performing_designs
 
 __all__ = [
     "ABTestManager",
@@ -11,4 +12,5 @@ __all__ = [
     "setup_scheduler",
     "update_weights",
     "ingest_metrics",
+    "highlight_low_performing_designs",
 ]

--- a/backend/feedback-loop/feedback_loop/highlighting.py
+++ b/backend/feedback-loop/feedback_loop/highlighting.py
@@ -1,0 +1,19 @@
+"""Helpers for identifying underperforming designs."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def highlight_low_performing_designs(
+    df: pd.DataFrame,
+    metric: str,
+    threshold: float,
+) -> list[int]:
+    """Return IDs of designs where ``metric`` is below ``threshold``."""
+    if "design_id" not in df.columns:
+        raise ValueError("design_id column missing")
+    if metric not in df.columns:
+        raise ValueError(f"Metric {metric} not found")
+    low = df[df[metric] < threshold]
+    return list(low["design_id"].astype(int).tolist())

--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -10,6 +10,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from .ab_testing import ABTestManager
 from .ingestion import ingest_metrics
 from .weight_updater import update_weights
+from .highlighting import highlight_low_performing_designs
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,9 @@ def setup_scheduler(
     def hourly_ingest() -> None:
         df = ingest_metrics(metrics_source)
         logger.info("processed metrics frame size %s", len(df))
+        low = highlight_low_performing_designs(df, "engagement", threshold=0.2)
+        if low:
+            logger.info("low performing designs %s", low)
 
     def nightly_update() -> None:
         weights = {

--- a/backend/feedback-loop/tests/test_highlighting.py
+++ b/backend/feedback-loop/tests/test_highlighting.py
@@ -1,0 +1,15 @@
+"""Tests for highlighting low-performing designs."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+from feedback_loop.highlighting import highlight_low_performing_designs
+
+
+def test_highlight_low_performing_designs() -> None:
+    df = pd.DataFrame({"design_id": [1, 2, 3], "engagement": [0.1, 0.5, 0.05]})
+    low = highlight_low_performing_designs(df, "engagement", 0.2)
+    assert low == [1, 3]

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings):  # type: ignore[misc]
     """Store configuration derived from environment variables."""
 
     model_config = SettingsConfigDict(env_file=".env")
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     rate_limit_amazon_merch: int = 60
     rate_limit_etsy: int = 60
     rate_limit_window: int = 60
+    slack_webhook_url: str | None = None
 
 
 settings = Settings()

--- a/backend/marketplace-publisher/tests/test_notifications.py
+++ b/backend/marketplace-publisher/tests/test_notifications.py
@@ -1,0 +1,20 @@
+"""Tests for notification functionality."""
+
+import pytest
+
+from marketplace_publisher.publisher import notify_failure
+from marketplace_publisher.db import Marketplace
+
+
+@pytest.mark.asyncio
+async def test_notify_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: bool = False
+
+    async def fake_post(url: str, json: dict[str, str], timeout: int) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://example.com")
+    monkeypatch.setattr("marketplace_publisher.publisher.requests.post", fake_post)
+    await notify_failure(1, Marketplace.redbubble, 2)
+    assert called

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -30,6 +30,9 @@ export default function AdminLayout({
           <Link href="/dashboard/maintenance" className="block hover:underline">
             {t('maintenance')}
           </Link>
+          <Link href="/dashboard/preferences" className="block hover:underline">
+            {t('preferences')}
+          </Link>
         </nav>
       </aside>
       <div className="flex flex-col flex-1">

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -12,5 +12,7 @@
   "maintenance": "Maintenance",
   "runCleanup": "Run Cleanup",
   "cleanupTriggered": "Cleanup triggered",
-  "cleanupFailed": "Cleanup failed"
+  "cleanupFailed": "Cleanup failed",
+  "preferences": "Preferences",
+  "emailAlerts": "Email alerts"
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function PreferencesPage() {
+  const { t } = useTranslation();
+  const [emailAlerts, setEmailAlerts] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('emailAlerts');
+    if (stored) {
+      setEmailAlerts(stored === 'true');
+    }
+  }, []);
+
+  const toggle = () => {
+    const value = !emailAlerts;
+    setEmailAlerts(value);
+    localStorage.setItem('emailAlerts', String(value));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-center space-x-2">
+        <input type="checkbox" checked={emailAlerts} onChange={toggle} />
+        <span>{t('emailAlerts')}</span>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- notify Slack when publish tasks fail
- expose low-performing design detection in feedback loop
- surface highlighted designs in scheduler
- allow preference settings in dashboard

## Testing
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/feedback-loop/feedback_loop/highlighting.py backend/feedback-loop/feedback_loop/scheduler.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/tests/test_notifications.py backend/feedback-loop/tests/test_highlighting.py`
- `mypy --ignore-missing-imports backend/feedback-loop/feedback_loop/highlighting.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/tests/test_highlighting.py backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/marketplace-publisher/tests/test_notifications.py` *(fails: Class cannot subclass "DeclarativeBase" ...)*
- `pytest backend/feedback-loop/tests/test_highlighting.py backend/marketplace-publisher/tests/test_notifications.py -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*
- `npx eslint frontend/admin-dashboard/src/pages/dashboard/preferences.tsx frontend/admin-dashboard/src/layouts/AdminLayout.tsx --fix`
- `npx stylelint "frontend/**/*.css"`

------
https://chatgpt.com/codex/tasks/task_b_6877fef29ca08331b7e79a82e6eb3aa0