### PR TITLE
Add currency conversion module

### DIFF
--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -3,5 +3,11 @@
 from .profiling import add_profiling
 from .tracing import configure_tracing
 from .logging import configure_logging
+from .currency import CurrencyConverter
 
-__all__ = ["add_profiling", "configure_tracing", "configure_logging"]
+__all__ = [
+    "add_profiling",
+    "configure_tracing",
+    "configure_logging",
+    "CurrencyConverter",
+]

--- a/backend/shared/currency.py
+++ b/backend/shared/currency.py
@@ -1,0 +1,67 @@
+"""Utility for currency conversion using Redis-backed exchange rates."""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Mapping
+
+import httpx
+from redis.asyncio import Redis
+
+
+class CurrencyConverter:
+    """Convert prices between currencies using cached exchange rates."""
+
+    def __init__(
+        self,
+        redis: Redis,
+        base_currency: str = "USD",
+        key: str = "exchange_rates",
+    ) -> None:
+        """Initialize the converter.
+
+        Args:
+            redis: Redis client instance.
+            base_currency: The base currency for the rates.
+            key: Redis key used to store the rates.
+        """
+        self._redis = redis
+        self.base_currency = base_currency
+        self.key = key
+
+    async def update_rates(self, api_url: str) -> None:
+        """Fetch latest rates from ``api_url`` and store them in Redis."""
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(api_url)
+            resp.raise_for_status()
+            data: Mapping[str, Any] = resp.json()
+        rates = data.get("rates")
+        if not isinstance(rates, Mapping):
+            raise ValueError("Invalid response from rate provider")
+        await self._redis.hset(self.key, mapping=dict(rates))
+        await self._redis.set(f"{self.key}:base", self.base_currency)
+
+    async def convert(
+        self, amount: float, from_currency: str, to_currency: str
+    ) -> float:
+        """Convert ``amount`` from ``from_currency`` to ``to_currency``."""
+        raw_from = await self._redis.hget(self.key, from_currency)
+        raw_to = await self._redis.hget(self.key, to_currency)
+        if raw_from is None or raw_to is None:
+            raise ValueError("Missing exchange rate")
+        rate_from = Decimal(
+            raw_from.decode() if isinstance(raw_from, bytes) else raw_from
+        )
+        rate_to = Decimal(raw_to.decode() if isinstance(raw_to, bytes) else raw_to)
+        decimal_amount = Decimal(str(amount)) / rate_from * rate_to
+        return float(decimal_amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+    async def schedule_updates(self, api_url: str, interval: int) -> None:
+        """Continually refresh rates every ``interval`` seconds."""
+        while True:  # pragma: no cover - infinite loop
+            try:
+                await self.update_rates(api_url)
+            except Exception:  # pragma: no cover - network failures
+                pass
+            await asyncio.sleep(interval)

--- a/docs/currency_conversion.md
+++ b/docs/currency_conversion.md
@@ -1,0 +1,9 @@
+# Currency Conversion
+
+Prices for marketplace listings may be displayed in different currencies. The
+`CurrencyConverter` class provides utilities for converting amounts using
+exchange rates stored in Redis.
+
+Exchange rates are refreshed periodically from a remote API and cached under the
+`exchange_rates` key. Conversions round to two decimal places using the
+``ROUND_HALF_UP`` strategy to ensure totals match marketplace expectations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Welcome to desAInz's documentation!
    security
    roles
    daily_summary
+   currency_conversion
    openapi_specs
 
 Kafka Utilities

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,21 @@
+"""Tests for currency conversion utilities."""
+
+from __future__ import annotations
+
+import pytest
+import fakeredis.aioredis
+
+from backend.shared.currency import CurrencyConverter
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_rounding_rules() -> None:
+    """Converted amounts should round half up to two decimals."""
+    redis = fakeredis.aioredis.FakeRedis()
+    converter = CurrencyConverter(redis)
+    await redis.hset("exchange_rates", mapping={"USD": 1, "EUR": 0.9})
+    result = await converter.convert(1.005, "USD", "USD")
+    assert result == 1.01
+    result = await converter.convert(10.0, "USD", "EUR")
+    assert result == 9.0
+    await redis.aclose()


### PR DESCRIPTION
## Summary
- provide a Redis-backed `CurrencyConverter`
- export `CurrencyConverter`
- document currency conversion module
- test rounding rules for conversions

## Testing
- `python -m mypy backend/shared/currency.py tests/test_currency.py --follow-imports skip`
- `python -m pytest tests/test_currency.py -W error` *(fails: Coverage failure)*
- `sphinx-build -W -b html docs docs/_build/html` *(fails: Could not import extension myst_parser)*

------
https://chatgpt.com/codex/tasks/task_b_6877fefaa05c833182d742e7d9c2abe3