### PR TITLE
Enable manual listing edits

### DIFF
--- a/backend/api-gateway/src/api_gateway/routes.py
+++ b/backend/api-gateway/src/api_gateway/routes.py
@@ -1,6 +1,9 @@
 """API routes including REST and tRPC-compatible endpoints."""
 
 from typing import Any, Dict
+import os
+
+import httpx
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
@@ -11,6 +14,11 @@ from .audit import log_admin_action
 from backend.shared.db import session_scope
 from backend.shared.db.models import AuditLog, UserRole
 from scripts import maintenance
+
+PUBLISHER_URL = os.environ.get(
+    "PUBLISHER_URL",
+    "http://marketplace-publisher:8000",
+)
 
 router = APIRouter()
 
@@ -122,3 +130,42 @@ async def get_audit_logs(
             for r in rows
         ],
     }
+
+
+@router.patch("/publish-tasks/{task_id}")
+async def edit_publish_task(
+    task_id: int,
+    body: Dict[str, Any],
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> Dict[str, str]:
+    """Edit metadata for a pending publish task."""
+    url = f"{PUBLISHER_URL}/tasks/{task_id}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.patch(url, json=body)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    log_admin_action(
+        payload.get("sub", "unknown"),
+        "edit_publish_task",
+        {"task_id": task_id, "metadata": body},
+    )
+    return {"status": "updated"}
+
+
+@router.post("/publish-tasks/{task_id}/retry")
+async def retry_publish_task(
+    task_id: int,
+    payload: Dict[str, Any] = Depends(require_role("admin")),
+) -> Dict[str, str]:
+    """Re-trigger publishing for a task."""
+    url = f"{PUBLISHER_URL}/tasks/{task_id}/retry"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url)
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, resp.text)
+    log_admin_action(
+        payload.get("sub", "unknown"),
+        "retry_publish_task",
+        {"task_id": task_id},
+    )
+    return {"status": "scheduled"}

--- a/backend/marketplace-publisher/src/marketplace_publisher/main.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/main.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Coroutine
+import json
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
 from pydantic import BaseModel
@@ -14,6 +15,8 @@ from redis.asyncio import Redis
 from .logging_config import configure_logging
 from .settings import settings
 from .rate_limiter import MarketplaceRateLimiter
+from sqlalchemy import update
+
 from .db import Marketplace, SessionLocal, create_task, get_task, init_db
 from .rules import load_rules, validate_mockup
 from .publisher import publish_with_retry
@@ -72,11 +75,25 @@ class PublishRequest(BaseModel):
     metadata: dict[str, Any] = {}
 
 
-async def _background_publish(task_id: int, req: PublishRequest) -> None:
-    """Wrap background publishing."""
+async def _background_publish(task_id: int) -> None:
+    """Run publishing using the latest task metadata."""
     async with SessionLocal() as session:
+        task = await get_task(session, task_id)
+        if task is None:
+            logger.error("publish task %s not found", task_id)
+            return
+        metadata = {}
+        if task.metadata_json:
+            try:
+                metadata = json.loads(task.metadata_json)
+            except json.JSONDecodeError:
+                logger.warning("invalid metadata for task %s", task_id)
         await publish_with_retry(
-            session, task_id, req.marketplace, req.design_path, req.metadata
+            session,
+            task_id,
+            task.marketplace,
+            Path(task.design_path),
+            metadata,
         )
 
 
@@ -100,7 +117,7 @@ async def publish(req: PublishRequest, background: BackgroundTasks) -> dict[str,
             design_path=str(req.design_path),
             metadata_json=req.metadata,
         )
-    background.add_task(_background_publish, task.id, req)
+    background.add_task(_background_publish, task.id)
     return {"task_id": task.id}
 
 
@@ -112,6 +129,35 @@ async def progress(task_id: int) -> dict[str, Any]:
         if task is None:
             raise HTTPException(status_code=404)
         return {"status": task.status, "attempts": task.attempts}
+
+
+@app.patch("/tasks/{task_id}")
+async def update_task_metadata(task_id: int, body: dict[str, Any]) -> dict[str, str]:
+    """Update metadata for a pending publish task."""
+    async with SessionLocal() as session:
+        task = await get_task(session, task_id)
+        if task is None:
+            raise HTTPException(status_code=404)
+        if task.status != PublishStatus.pending:
+            raise HTTPException(status_code=400, detail="Task already started")
+        await session.execute(
+            update(PublishTask)
+            .where(PublishTask.id == task_id)
+            .values(metadata_json=json.dumps(body))
+        )
+        await session.commit()
+    return {"status": "updated"}
+
+
+@app.post("/tasks/{task_id}/retry")
+async def retry_task(task_id: int, background: BackgroundTasks) -> dict[str, str]:
+    """Re-trigger publishing for a task."""
+    async with SessionLocal() as session:
+        task = await get_task(session, task_id)
+        if task is None:
+            raise HTTPException(status_code=404)
+    background.add_task(_background_publish, task_id)
+    return {"status": "scheduled"}
 
 
 @app.get("/health")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Welcome to desAInz's documentation!
    load_testing
    mocking
    maintenance
+   publish_tasks
    i18n
    security
    roles

--- a/docs/publish_tasks.md
+++ b/docs/publish_tasks.md
@@ -1,0 +1,9 @@
+# Manual Listing Overrides
+
+Administrators can adjust listing metadata prior to publishing using the API Gateway.
+
+`PATCH /publish-tasks/{task_id}` updates the stored metadata for a pending publish task. The body accepts arbitrary JSON fields used by the marketplace publisher.
+
+`POST /publish-tasks/{task_id}/retry` re-triggers the publishing workflow for the task.
+
+All edits and retries are recorded in the audit log.

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -21,6 +21,9 @@ export default function AdminLayout({
           <Link href="/dashboard/gallery" className="block hover:underline">
             {t('gallery')}
           </Link>
+          <Link href="/dashboard/publish" className="block hover:underline">
+            {t('updateAndPublish')}
+          </Link>
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             {t('abTests')}
           </Link>

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -12,5 +12,8 @@
   "maintenance": "Maintenance",
   "runCleanup": "Run Cleanup",
   "cleanupTriggered": "Cleanup triggered",
-  "cleanupFailed": "Cleanup failed"
+  "cleanupFailed": "Cleanup failed",
+  "updateAndPublish": "Update & Publish",
+  "updateFailed": "Update failed",
+  "publishScheduled": "Publish scheduled"
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../../components/Button';
+
+export default function PublishPage() {
+  const { t } = useTranslation();
+  const [taskId, setTaskId] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+  const [status, setStatus] = useState('');
+
+  const submit = async () => {
+    const metadata = { title, description, price: parseFloat(price) };
+    const token = localStorage.getItem('token');
+    const resp = await fetch(`/publish-tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token,
+      },
+      body: JSON.stringify(metadata),
+    });
+    if (!resp.ok) {
+      setStatus(t('updateFailed'));
+      return;
+    }
+    const retry = await fetch(`/publish-tasks/${taskId}/retry`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' + token },
+    });
+    setStatus(retry.ok ? t('publishScheduled') : t('updateFailed'));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div>
+        Task ID{' '}
+        <input
+          value={taskId}
+          onChange={(e) => setTaskId(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <div>
+        Title{' '}
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <div>
+        Description{' '}
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <div>
+        Price{' '}
+        <input
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <Button onClick={submit}>{t('updateAndPublish')}</Button>
+      {status && <div>{status}</div>}
+    </div>
+  );
+}
+
+export const getStaticProps = async () => {
+  return {
+    props: {},
+    revalidate: 60,
+  };
+};


### PR DESCRIPTION
## Summary
- support editing and retrying publish tasks in API Gateway
- fetch latest metadata when running publish tasks
- expose publisher controls in admin dashboard
- document manual listing overrides

## Testing
- `pre-commit run --files backend/marketplace-publisher/src/marketplace_publisher/main.py backend/api-gateway/src/api_gateway/routes.py frontend/admin-dashboard/src/pages/dashboard/publish.tsx frontend/admin-dashboard/src/layouts/AdminLayout.tsx frontend/admin-dashboard/src/locales/en/common.json docs/publish_tasks.md docs/index.rst` *(fails: could not access github.com)*
- `pytest -q -o addopts=''` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6877ff0716c48331913c37da1327a729