### PR TITLE
Add AI model management

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -34,13 +34,13 @@ async def add_correlation_id(
     return response
 
 
-@app.get("/health")  # type: ignore[misc]
+@app.get("/health")
 async def health() -> dict[str, str]:
     """Return service liveness."""
     return {"status": "ok"}
 
 
-@app.get("/ready")  # type: ignore[misc]
+@app.get("/ready")
 async def ready() -> dict[str, str]:
     """Return service readiness."""
     return {"status": "ready"}

--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -12,6 +12,8 @@ import requests
 from diffusers import StableDiffusionXLPipeline
 import torch
 
+from .model_repository import get_default_model_id
+
 
 logger = logging.getLogger(__name__)
 
@@ -27,16 +29,16 @@ class GenerationResult:
 class MockupGenerator:
     """Generate mockups using Stable Diffusion XL with fallback."""
 
-    def __init__(
-        self, model_id: str = "stabilityai/stable-diffusion-xl-base-1.0"
-    ) -> None:
-        """Initialize the generator with the model identifier."""
-        self.model_id = model_id
+    def __init__(self) -> None:
+        """Initialize the generator and defer model lookup."""
+        self.model_id = get_default_model_id()
         self.pipeline: Optional[StableDiffusionXLPipeline] = None
 
     def load(self) -> None:
         """Load the diffusion pipeline on GPU if available."""
-        if self.pipeline is None:
+        current = get_default_model_id()
+        if self.pipeline is None or self.model_id != current:
+            self.model_id = current
             device = "cuda" if torch.cuda.is_available() else "cpu"
             self.pipeline = StableDiffusionXLPipeline.from_pretrained(self.model_id).to(
                 device

--- a/backend/mockup-generation/mockup_generation/model_repository.py
+++ b/backend/mockup-generation/mockup_generation/model_repository.py
@@ -1,0 +1,61 @@
+"""Database helpers for managing AI model metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from sqlalchemy import select, update
+
+from backend.shared.db import engine, session_scope
+from backend.shared.db.base import Base
+from backend.shared.db.models import AIModel
+
+Base.metadata.create_all(bind=engine)
+
+
+@dataclass
+class ModelInfo:
+    """Dataclass representing an AI model entry."""
+
+    id: int
+    name: str
+    version: str
+    model_id: str
+    details: dict[str, object] | None
+    is_default: bool
+
+
+def list_models() -> List[ModelInfo]:
+    """Return all registered models."""
+    with session_scope() as session:
+        rows: Iterable[AIModel] = session.scalars(select(AIModel)).all()
+        return [
+            ModelInfo(
+                id=row.id,
+                name=row.name,
+                version=row.version,
+                model_id=row.model_id,
+                details=row.details,
+                is_default=row.is_default,
+            )
+            for row in rows
+        ]
+
+
+def set_default(model_id: int) -> None:
+    """Set ``model_id`` as the default model."""
+    with session_scope() as session:
+        if session.get(AIModel, model_id) is None:
+            raise ValueError("model not found")
+        session.execute(update(AIModel).values(is_default=False))
+        session.execute(
+            update(AIModel).where(AIModel.id == model_id).values(is_default=True)
+        )
+
+
+def get_default_model_id() -> str:
+    """Return the current default model identifier."""
+    with session_scope() as session:
+        ident = session.scalar(select(AIModel.model_id).where(AIModel.is_default))
+    return ident or "stabilityai/stable-diffusion-xl-base-1.0"

--- a/backend/mockup-generation/mockup_generation/prompt_builder.py
+++ b/backend/mockup-generation/mockup_generation/prompt_builder.py
@@ -18,7 +18,8 @@ class PromptContext:
 
 
 TEMPLATE = Template(
-    "A {{ style }} design featuring {{ keywords | join(', ') }}. {{ extra.get('note', '') }}"
+    "A {{ style }} design featuring {{ keywords | join(', ') }}. "
+    "{{ extra.get('note', '') }}"
 )
 
 

--- a/backend/shared/db/base.py
+++ b/backend/shared/db/base.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase
 
 
-class Base(DeclarativeBase):  # type: ignore[misc]
+class Base(DeclarativeBase):
     """Base class for all ORM models."""

--- a/backend/shared/db/migrations/scoring_engine/versions/0005_add_ai_models_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0005_add_ai_models_table.py
@@ -1,0 +1,35 @@
+"""Add ai_models table for tracking model versions."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create ai_models table."""
+    op.create_table(
+        "ai_models",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("version", sa.String(length=50), nullable=False),
+        sa.Column("model_id", sa.String(), nullable=False, unique=True),
+        sa.Column("details", sa.JSON(), nullable=True),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop ai_models table."""
+    op.drop_table("ai_models")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from typing import Any
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, JSON
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -142,3 +142,17 @@ class AuditLog(Base):
     action: Mapped[str] = mapped_column(String(100))
     details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class AIModel(Base):
+    """AI model metadata tracked in the database."""
+
+    __tablename__ = "ai_models"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    version: Mapped[str] = mapped_column(String(50))
+    model_id: Mapped[str] = mapped_column(String, unique=True)
+    details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/shared/profiling.py
+++ b/backend/shared/profiling.py
@@ -16,7 +16,7 @@ def add_profiling(app: FastAPI | Flask) -> None:
     """Attach middleware to profile request durations."""
     if isinstance(app, FastAPI):
 
-        @app.middleware("http")  # type: ignore[misc]
+        @app.middleware("http")
         async def _profile(
             request: Request,
             call_next: Callable[[Request], Coroutine[Any, Any, Response]],
@@ -32,11 +32,11 @@ def add_profiling(app: FastAPI | Flask) -> None:
 
     else:
 
-        @app.before_request  # type: ignore[misc]
+        @app.before_request
         def _before_request() -> None:
             setattr(flask_request, "_start_time", time.perf_counter())
 
-        @app.after_request  # type: ignore[misc]
+        @app.after_request
         def _after_request(response: Response) -> Response:
             start = getattr(flask_request, "_start_time", None)
             if start is not None:

--- a/backend/shared/tracing.py
+++ b/backend/shared/tracing.py
@@ -29,4 +29,4 @@ def configure_tracing(app: FastAPI | Flask, service_name: str) -> None:
     if isinstance(app, FastAPI):
         FastAPIInstrumentor.instrument_app(app)
     else:
-        FlaskInstrumentor().instrument_app(app)
+        FlaskInstrumentor().instrument_app(app)  # type: ignore[no-untyped-call]

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -5,3 +5,6 @@ Mockup Generation
 
 .. automodule:: mockup_generation.generator
    :members:
+
+.. automodule:: mockup_generation.model_repository
+   :members:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests package."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,13 +3,15 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "backend" / "optimization"))
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "optimization")
+)  # noqa: E402
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from backend.optimization.api import app
+from backend.optimization.api import app  # noqa: E402
 
 
 client = TestClient(app)

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,0 +1,41 @@
+"""Tests for model management API endpoints."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "backend" / "api-gateway" / "src")
+)  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+from api_gateway.main import app  # noqa: E402
+from backend.shared.db import session_scope  # noqa: E402
+from backend.shared.db.models import AIModel, UserRole  # noqa: E402
+from api_gateway.auth import create_access_token  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_switch_default_model() -> None:
+    """Switch active model via the API and verify database state."""
+    token = create_access_token({"sub": "admin"})
+    with session_scope() as session:
+        session.add(UserRole(username="admin", role="admin"))
+        session.add(
+            AIModel(id=1, name="base", version="1", model_id="model/a", is_default=True)
+        )
+        session.add(
+            AIModel(id=2, name="new", version="2", model_id="model/b", is_default=False)
+        )
+        session.flush()
+
+    headers = {"Authorization": f"Bearer {token}"}
+    response = client.get("/models", headers=headers)
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+    response = client.post("/models/2/default", headers=headers)
+    assert response.status_code == 200
+    with session_scope() as session:
+        model2 = session.get(AIModel, 2)
+        assert model2 is not None and model2.is_default

--- a/tests/test_kafka_utils.py
+++ b/tests/test_kafka_utils.py
@@ -29,7 +29,6 @@ class DummyProducer:
 
 def test_producer_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure messages are validated before being sent."""
-
     registry = SchemaRegistryClient("http://registry")
     monkeypatch.setattr(
         registry,
@@ -73,7 +72,6 @@ class DummyConsumer:
 
 def test_consumer_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure consumed messages are validated."""
-
     registry = SchemaRegistryClient("http://registry")
     schema = {
         "type": "object",

--- a/tests/test_model_repository.py
+++ b/tests/test_model_repository.py
@@ -1,0 +1,28 @@
+"""Unit tests for model repository helpers."""
+
+from mockup_generation.model_repository import (
+    get_default_model_id,
+    set_default,
+    list_models,
+)
+from backend.shared.db import session_scope
+from backend.shared.db.models import AIModel
+from pathlib import Path
+
+
+def test_default_model_switch(tmp_path: Path) -> None:
+    """Verify ``set_default`` updates the active model."""
+    with session_scope() as session:
+        session.add(
+            AIModel(id=1, name="base", version="1", model_id="model/a", is_default=True)
+        )
+        session.add(
+            AIModel(id=2, name="new", version="2", model_id="model/b", is_default=False)
+        )
+        session.flush()
+
+    assert get_default_model_id() == "model/a"
+    set_default(2)
+    assert get_default_model_id() == "model/b"
+    models = list_models()
+    assert len(models) == 2

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -5,11 +5,11 @@ import sys
 
 sys.path.append(
     str(Path(__file__).resolve().parents[1] / "backend" / "monitoring" / "src")
-)
+)  # noqa: E402
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from monitoring.main import app
+from monitoring.main import app  # noqa: E402
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- track AI model metadata in database
- switch default model for mockup generation via API
- reload generator pipeline when default changes
- document new module in Sphinx docs
- add tests for model repository and API
- create Alembic migration for ai_models table

## Testing
- `flake8 backend/mockup-generation/mockup_generation backend/api-gateway/src/api_gateway backend/shared/db tests --count`
- `mypy --ignore-missing-imports backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/model_repository.py backend/api-gateway/src/api_gateway/routes.py tests/test_api_models.py tests/test_model_repository.py`
- `pytest -W error` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_b_6877ff153d248331b900124cf5282b54