### PR TITLE
Add notifications and low performer features

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/notifications.py
@@ -1,0 +1,26 @@
+"""Notification helpers for publisher errors."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+def notify_failure(task_id: int, marketplace: str) -> None:
+    """Send a Slack notification about a failed publish task."""
+    webhook = os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook:
+        return
+    payload: dict[str, Any] = {
+        "text": f"Publish task {task_id} failed for {marketplace}",
+    }
+    try:
+        requests.post(webhook, json=payload, timeout=5)
+    except requests.RequestException as exc:  # pragma: no cover - best effort
+        logger.warning("notification failed: %s", exc)

--- a/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/publisher.py
@@ -16,6 +16,7 @@ from .clients import (
     SeleniumFallback,
 )
 from .trademark import is_trademarked
+from .notifications import notify_failure
 from .db import (
     Marketplace,
     PublishStatus,
@@ -49,6 +50,7 @@ async def publish_with_retry(
         title = str(metadata.get("title", ""))
         if title and is_trademarked(title):
             await update_task_status(session, task_id, PublishStatus.failed)
+            notify_failure(task_id, marketplace.value)
             return
 
         client = CLIENTS[marketplace]
@@ -67,3 +69,4 @@ async def publish_with_retry(
             await update_task_status(session, task_id, PublishStatus.success)
         else:
             await update_task_status(session, task_id, PublishStatus.failed)
+            notify_failure(task_id, marketplace.value)

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     unleash_url: str | None = None
     unleash_api_token: str | None = None
     unleash_app_name: str = "marketplace-publisher"
+    slack_webhook_url: str | None = None
 
 
 settings = Settings()

--- a/docs/publish_tasks.md
+++ b/docs/publish_tasks.md
@@ -7,3 +7,5 @@ Administrators can adjust listing metadata prior to publishing using the API Gat
 `POST /publish-tasks/{task_id}/retry` re-triggers the publishing workflow for the task.
 
 All edits and retries are recorded in the audit log.
+
+If `SLACK_WEBHOOK_URL` is configured, failed publish attempts send a Slack notification.

--- a/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
+++ b/frontend/admin-dashboard/src/layouts/AdminLayout.tsx
@@ -24,11 +24,17 @@ export default function AdminLayout({
           <Link href="/dashboard/publish" className="block hover:underline">
             {t('updateAndPublish')}
           </Link>
+          <Link href="/dashboard/low-performers" className="block hover:underline">
+            {t('lowPerformers')}
+          </Link>
           <Link href="/dashboard/ab-tests" className="block hover:underline">
             {t('abTests')}
           </Link>
           <Link href="/dashboard/roles" className="block hover:underline">
             {t('roles')}
+          </Link>
+          <Link href="/dashboard/preferences" className="block hover:underline">
+            {t('preferences')}
           </Link>
           <Link href="/dashboard/maintenance" className="block hover:underline">
             {t('maintenance')}

--- a/frontend/admin-dashboard/src/locales/en/common.json
+++ b/frontend/admin-dashboard/src/locales/en/common.json
@@ -15,5 +15,8 @@
   "cleanupFailed": "Cleanup failed",
   "updateAndPublish": "Update & Publish",
   "updateFailed": "Update failed",
-  "publishScheduled": "Publish scheduled"
+  "publishScheduled": "Publish scheduled",
+  "lowPerformers": "Low Performing Listings",
+  "preferences": "Preferences",
+  "notifyOnFail": "Notify on publish failure"
 }

--- a/frontend/admin-dashboard/src/pages/dashboard/low-performers.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/low-performers.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Performer {
+  listing_id: number;
+  revenue: number;
+}
+
+export default function LowPerformersPage() {
+  const { t } = useTranslation();
+  const [items, setItems] = useState<Performer[]>([]);
+  const base = process.env.NEXT_PUBLIC_ANALYTICS_URL ?? 'http://localhost:8000';
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch(`${base}/low_performers`);
+        if (res.ok) {
+          setItems(await res.json());
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    void fetchData();
+  }, [base]);
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-bold">{t('lowPerformers')}</h2>
+      <ul>
+        {items.map((p) => (
+          <li key={p.listing_id} className="text-red-600">
+            {p.listing_id}: ${p.revenue.toFixed(2)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/preferences.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function PreferencesPage() {
+  const { t } = useTranslation();
+  const [notify, setNotify] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('notifyFail');
+    if (stored) {
+      setNotify(stored === 'true');
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = !notify;
+    setNotify(next);
+    localStorage.setItem('notifyFail', String(next));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-center space-x-2">
+        <input type="checkbox" checked={notify} onChange={toggle} />
+        <span>{t('notifyOnFail')}</span>
+      </label>
+    </div>
+  );
+}

--- a/openapi/analytics.json
+++ b/openapi/analytics.json
@@ -171,6 +171,43 @@
         }
       }
     },
+    "/low_performers": {
+      "get": {
+        "summary": "Low Performers",
+        "description": "Return listings with the lowest total revenue.",
+        "operationId": "low_performers_low_performers_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer", "title": "Limit", "default": 10}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {"$ref": "#/components/schemas/LowPerformer"},
+                  "type": "array",
+                  "title": "Response Low Performers Low Performers Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "summary": "Health",
@@ -285,6 +322,16 @@
         ],
         "title": "MarketplaceSummary",
         "description": "Aggregated metrics for a listing."
+      },
+      "LowPerformer": {
+        "properties": {
+          "listing_id": {"type": "integer", "title": "Listing Id"},
+          "revenue": {"type": "number", "title": "Revenue"}
+        },
+        "type": "object",
+        "required": ["listing_id", "revenue"],
+        "title": "LowPerformer",
+        "description": "Listing with the lowest revenue."
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
## Summary
- notify via Slack when publish tasks fail
- expose low performer listings via analytics service
- document notification option
- add low performer and preference pages to dashboard
- update navigation and translations

## Testing
- `npm run lint` *(fails: react undefined and other lint errors)*
- `python -m flake8` *(fails: many style errors)*
- `python -m mypy backend/analytics/api.py backend/marketplace-publisher/src/marketplace_publisher/notifications.py` *(fails: missing stubs)*
- `python -m pytest` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_b_6878028e57c8833199bc67f8fe2db6d3