### PR TITLE
Improve dashboard loading

### DIFF
--- a/frontend/admin-dashboard/src/components/RolesList.tsx
+++ b/frontend/admin-dashboard/src/components/RolesList.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+
+interface Assignment {
+  username: string;
+  role: string;
+}
+
+export function RolesList() {
+  const [roles, setRoles] = useState<Assignment[]>([]);
+  useEffect(() => {
+    async function load() {
+      const resp = await fetch('/roles', {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+      });
+      if (resp.ok) {
+        setRoles(await resp.json());
+      }
+    }
+    void load();
+  }, []);
+  return (
+    <ul>
+      {roles.map((r) => (
+        <li key={r.username}>
+          {r.username}: {r.role}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '../../components/Button';
+import dynamic from 'next/dynamic';
+
+const Button = dynamic(() => import('../../components/Button'));
 
 export default function MaintenancePage() {
   const { t } = useTranslation();

--- a/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/publish.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '../../components/Button';
+import dynamic from 'next/dynamic';
+
+const Button = dynamic(() => import('../../components/Button'));
 
 export default function PublishPage() {
   const { t } = useTranslation();

--- a/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
+++ b/frontend/admin-dashboard/src/pages/dashboard/roles.tsx
@@ -1,36 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import type { GetStaticProps } from 'next';
 import { useTranslation } from 'react-i18next';
+import dynamic from 'next/dynamic';
 
-interface Assignment {
-  username: string;
-  role: string;
-}
+const RolesList = dynamic(() => import('../../components/RolesList'));
 
 export default function RolesPage() {
   const { t } = useTranslation();
-  const [roles, setRoles] = useState<Assignment[]>([]);
-  useEffect(() => {
-    async function load() {
-      const resp = await fetch('/roles', {
-        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
-      });
-      if (resp.ok) {
-        setRoles(await resp.json());
-      }
-    }
-    void load();
-  }, []);
   return (
     <div>
       <h1>{t('roles')}</h1>
-      <ul>
-        {roles.map((r) => (
-          <li key={r.username}>
-            {r.username}: {r.role}
-          </li>
-        ))}
-      </ul>
+      <RolesList />
     </div>
   );
 }

--- a/frontend/docs/performance.md
+++ b/frontend/docs/performance.md
@@ -1,0 +1,10 @@
+# Performance Monitoring
+
+The `next build --profile` command was executed to gather bundle size information. The build failed because Tailwind CSS was configured as a direct PostCSS plugin. The error message suggested installing `@tailwindcss/postcss` and updating the PostCSS configuration.
+
+```
+Import trace for requested module:
+./src/styles/globals.css
+
+> Build failed because of webpack errors
+```


### PR DESCRIPTION
## Summary
- dynamically import admin dashboard features
- capture results from `next build --profile`
- document performance notes

## Testing
- `npx prettier -w frontend/admin-dashboard/src/pages/dashboard/publish.tsx frontend/admin-dashboard/src/pages/dashboard/maintenance.tsx frontend/admin-dashboard/src/components/RolesList.tsx frontend/admin-dashboard/src/pages/dashboard/roles.tsx frontend/docs/performance.md`
- `npm --prefix frontend/admin-dashboard run lint`
- `npm run lint:stylelint` *(fails: stylelint: not found)*
- `npm run lint:prettier` *(fails: code style issues found)*
- `flake8` *(fails: multiple style errors)*
- `mypy backend` *(fails: 1 error)*
- `pytest -W error` *(fails: unrecognized arguments --cov)*


------
https://chatgpt.com/codex/tasks/task_b_687804151564833184295439e8f326a8