### PR TITLE
Implement parallel ingestion workers

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/celery_app.py
+++ b/backend/signal-ingestion/src/signal_ingestion/celery_app.py
@@ -1,0 +1,12 @@
+"""Celery application for signal ingestion."""
+
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+app = Celery("signal_ingestion", broker=CELERY_BROKER_URL)
+app.conf.result_backend = CELERY_BROKER_URL

--- a/backend/signal-ingestion/src/signal_ingestion/ingestion.py
+++ b/backend/signal-ingestion/src/signal_ingestion/ingestion.py
@@ -3,44 +3,16 @@
 from __future__ import annotations
 
 
+import asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .adapters.events import EventsAdapter
-from .adapters.instagram import InstagramAdapter
-from .adapters.nostalgia import NostalgiaAdapter
-from .adapters.reddit import RedditAdapter
-from .adapters.tiktok import TikTokAdapter
-from .adapters.youtube import YouTubeAdapter
-from .dedup import add_key, is_duplicate
-from .models import Signal
-from .publisher import publish
-from .privacy import purge_row
 from .retention import purge_old_signals
 from .settings import settings
-
-
-ADAPTERS = [
-    TikTokAdapter("https://jsonplaceholder.typicode.com"),
-    InstagramAdapter("https://jsonplaceholder.typicode.com"),
-    RedditAdapter("https://jsonplaceholder.typicode.com"),
-    YouTubeAdapter("https://jsonplaceholder.typicode.com"),
-    EventsAdapter("https://jsonplaceholder.typicode.com"),
-    NostalgiaAdapter("https://jsonplaceholder.typicode.com"),
-]
+from .tasks import ADAPTERS as TASK_ADAPTERS, schedule_ingestion
 
 
 async def ingest(session: AsyncSession) -> None:
-    """Fetch signals from adapters and store them."""
+    """Schedule ingestion tasks for all adapters."""
     await purge_old_signals(session, settings.signal_retention_days)
-    for adapter in ADAPTERS:
-        rows = await adapter.fetch()
-        for row in rows:
-            key = f"{adapter.__class__.__name__}:{row['id']}"
-            if is_duplicate(key):
-                continue
-            add_key(key)
-            clean_row = purge_row(row)
-            signal = Signal(source=adapter.__class__.__name__, content=str(clean_row))
-            session.add(signal)
-            await session.commit()
-            publish("signals", key)
+    adapter_names = list(TASK_ADAPTERS.keys())
+    await asyncio.to_thread(schedule_ingestion, adapter_names)

--- a/backend/signal-ingestion/src/signal_ingestion/tasks.py
+++ b/backend/signal-ingestion/src/signal_ingestion/tasks.py
@@ -1,0 +1,76 @@
+"""Celery tasks for parallel signal ingestion."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .adapters.base import BaseAdapter
+from .adapters.events import EventsAdapter
+from .adapters.instagram import InstagramAdapter
+from .adapters.nostalgia import NostalgiaAdapter
+from .adapters.reddit import RedditAdapter
+from .adapters.tiktok import TikTokAdapter
+from .adapters.youtube import YouTubeAdapter
+from .celery_app import app
+from .database import SessionLocal
+from .dedup import add_key, is_duplicate
+from .models import Signal
+from .privacy import purge_row
+from .publisher import publish
+from .retention import purge_old_signals
+from .settings import settings
+
+
+ADAPTERS: dict[str, BaseAdapter] = {
+    "tiktok": TikTokAdapter("https://jsonplaceholder.typicode.com"),
+    "instagram": InstagramAdapter("https://jsonplaceholder.typicode.com"),
+    "reddit": RedditAdapter("https://jsonplaceholder.typicode.com"),
+    "youtube": YouTubeAdapter("https://jsonplaceholder.typicode.com"),
+    "events": EventsAdapter("https://jsonplaceholder.typicode.com"),
+    "nostalgia": NostalgiaAdapter("https://jsonplaceholder.typicode.com"),
+}
+
+
+async def _ingest_from_adapter(session: AsyncSession, adapter: BaseAdapter) -> None:
+    await purge_old_signals(session, settings.signal_retention_days)
+    rows = await adapter.fetch()
+    for row in rows:
+        key = f"{adapter.__class__.__name__}:{row['id']}"
+        if is_duplicate(key):
+            continue
+        add_key(key)
+        clean_row = purge_row(row)
+        signal = Signal(source=adapter.__class__.__name__, content=str(clean_row))
+        session.add(signal)
+        await session.commit()
+        publish("signals", key)
+
+
+@app.task(name="signal_ingestion.ingest_adapter")  # type: ignore[misc]
+def ingest_adapter_task(adapter_name: str) -> None:
+    """Run ingestion for the adapter named ``adapter_name``."""
+
+    async def runner() -> None:
+        adapter = ADAPTERS[adapter_name]
+        async with SessionLocal() as session:
+            await _ingest_from_adapter(session, adapter)
+
+    asyncio.run(runner())
+
+
+def queue_for(adapter_name: str) -> str:
+    """Return queue name for ``adapter_name``."""
+    return f"ingestion_{adapter_name}"
+
+
+def schedule_ingestion(adapter_names: Iterable[str]) -> None:
+    """Dispatch ingestion tasks for ``adapter_names``."""
+    for name in adapter_names:
+        app.send_task(
+            "signal_ingestion.ingest_adapter",
+            args=[name],
+            queue=queue_for(name),
+        )

--- a/backend/signal-ingestion/tests/test_parallel_ingestion.py
+++ b/backend/signal-ingestion/tests/test_parallel_ingestion.py
@@ -1,0 +1,34 @@
+"""Test scheduling of ingestion tasks across queues."""
+
+from __future__ import annotations
+
+from signal_ingestion import tasks
+
+
+class DummyApp:
+    """Collect Celery send_task calls."""
+
+    def __init__(self) -> None:
+        """Initialize storage for sent tasks."""
+        self.sent: list[tuple[str, list[str], str | None]] = []
+
+    def send_task(
+        self, name: str, args: list[str] | None = None, queue: str | None = None
+    ) -> None:
+        """Record a send_task call."""
+        self.sent.append((name, args or [], queue))
+
+
+def test_schedule_ingestion(monkeypatch) -> None:
+    """Ensure each adapter is dispatched to its own queue."""
+    dummy = DummyApp()
+    monkeypatch.setattr(tasks, "app", dummy)
+    tasks.schedule_ingestion(["tiktok", "instagram"])
+    assert dummy.sent == [
+        ("signal_ingestion.ingest_adapter", ["tiktok"], tasks.queue_for("tiktok")),
+        (
+            "signal_ingestion.ingest_adapter",
+            ["instagram"],
+            tasks.queue_for("instagram"),
+        ),
+    ]

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,62 @@
+"""Stress test concurrent scoring and generation."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+import fakeredis
+from PIL import Image
+
+from scoring_engine.app import app as scoring_app, redis_client
+from scoring_engine.weight_repository import update_weights
+from mockup_generation.generator import MockupGenerator
+
+
+def _setup_scoring() -> ThreadPoolExecutor:
+    scoring_app.config.update(TESTING=True)
+    redis_client.connection_pool.connection_class = fakeredis.FakeConnection
+    update_weights(
+        freshness=1.0,
+        engagement=1.0,
+        novelty=1.0,
+        community_fit=1.0,
+        seasonality=1.0,
+    )
+    return ThreadPoolExecutor(max_workers=5)
+
+
+def _fake_load(self: MockupGenerator) -> None:  # noqa: D401 - short helper
+    """Patch pipeline with a dummy implementation."""
+    self.pipeline = type(
+        "P",
+        (),
+        {
+            "__call__": lambda _self, prompt, num_inference_steps=30: type(
+                "R", (), {"images": [Image.new("RGB", (1, 1))]}
+            )()
+        },
+    )()
+
+
+def _worker(client, gen: MockupGenerator, tmp: Path, idx: int) -> None:
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "engagement_rate": 1.0,
+        "embedding": [1.0, 0.0],
+        "metadata": {},
+    }
+    client.post("/score", json=payload)
+    gen.generate("test", str(tmp / f"{idx}.png"), num_inference_steps=1)
+
+
+def test_parallel_services(monkeypatch, tmp_path) -> None:
+    """Run scoring and generation concurrently without errors."""
+    executor = _setup_scoring()
+    gen = MockupGenerator()
+    monkeypatch.setattr(MockupGenerator, "load", _fake_load)
+
+    client = scoring_app.test_client()
+    with executor:
+        list(executor.map(lambda i: _worker(client, gen, tmp_path, i), range(10)))


### PR DESCRIPTION
## Summary
- parallelize signal ingestion with Celery tasks
- add thread-safe loading for generator and CLIP utilities
- schedule ingestion jobs from API
- test Celery queue selection logic
- stress test concurrent scoring and generation

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/tasks.py backend/signal-ingestion/src/signal_ingestion/ingestion.py backend/mockup-generation/mockup_generation/generator.py backend/mockup-generation/mockup_generation/post_processor.py backend/signal-ingestion/tests/test_parallel_ingestion.py tests/test_concurrency.py backend/signal-ingestion/src/signal_ingestion/celery_app.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/tasks.py` *(fails: Class cannot subclass "BaseSettings")*
- `make test` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6878040a71788331841c57e0060b34e0