### PR TITLE
Add currency conversion with Redis

### DIFF
--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -6,6 +6,7 @@ from .logging import configure_logging
 from .feature_flags import initialize as init_feature_flags, is_enabled
 
 from .errors import add_error_handlers, add_flask_error_handlers
+from .currency import convert_price, start_rate_updater
 
 __all__ = [
     "add_profiling",
@@ -15,4 +16,6 @@ __all__ = [
     "add_error_handlers",
     "add_flask_error_handlers",
     "is_enabled",
+    "convert_price",
+    "start_rate_updater",
 ]

--- a/backend/shared/currency.py
+++ b/backend/shared/currency.py
@@ -1,0 +1,68 @@
+"""Currency conversion utilities with Redis caching."""
+
+from __future__ import annotations
+
+import json
+import logging
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Dict
+import os
+
+import requests
+import redis
+from apscheduler.schedulers.background import BackgroundScheduler
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+EXCHANGE_API_URL = os.environ.get(
+    "EXCHANGE_API_URL", "https://api.exchangerate.host/latest"
+)
+BASE_CURRENCY = os.environ.get("BASE_CURRENCY", "USD")
+REDIS_KEY = "exchange_rates"
+
+redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+scheduler = BackgroundScheduler()
+
+
+def _fetch_rates(base: str = BASE_CURRENCY) -> Dict[str, float]:
+    """Fetch latest exchange rates from external API."""
+    response = requests.get(EXCHANGE_API_URL, params={"base": base}, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("rates", {})
+
+
+def update_rates() -> None:
+    """Fetch and store exchange rates in Redis."""
+    rates = _fetch_rates()
+    redis_client.set(REDIS_KEY, json.dumps(rates))
+    logger.info("stored %d exchange rates", len(rates))
+
+
+def start_rate_updater() -> None:
+    """Start scheduler for periodic exchange rate updates."""
+    scheduler.add_job(update_rates, "interval", hours=1, next_run_time=None)
+    scheduler.start()
+
+
+def get_rate(currency: str) -> float:
+    """Return rate for ``currency`` relative to base currency."""
+    data = redis_client.get(REDIS_KEY)
+    if data is None:
+        update_rates()
+        data = redis_client.get(REDIS_KEY) or "{}"
+    rates = json.loads(data)
+    if currency not in rates:
+        raise KeyError(currency)
+    return float(rates[currency])
+
+
+def convert_price(amount: float, currency: str) -> float:
+    """Convert ``amount`` from base currency to ``currency`` rounded to cents."""
+    rate = get_rate(currency)
+    quantized = (Decimal(str(amount)) * Decimal(str(rate))).quantize(
+        Decimal("0.01"),
+        rounding=ROUND_HALF_UP,
+    )
+    return float(quantized)

--- a/backend/shared/tests/test_currency.py
+++ b/backend/shared/tests/test_currency.py
@@ -1,0 +1,40 @@
+"""Tests for currency conversion utilities."""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "currency", Path(__file__).resolve().parents[1] / "currency.py"
+)
+currency = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(currency)
+
+
+def setup_module(module: object) -> None:
+    """Use fakeredis for tests."""
+    currency.redis_client = fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture(autouse=True)
+def _mock_rates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock rate fetching to provide deterministic values."""
+    rates = {"EUR": 0.8456}
+
+    def _fake_fetch(base: str = currency.BASE_CURRENCY) -> dict[str, float]:
+        return rates
+
+    monkeypatch.setattr(currency, "_fetch_rates", _fake_fetch)
+    currency.redis_client.flushall()
+    currency.update_rates()
+
+
+def test_convert_price_rounding() -> None:
+    """Converted amounts are rounded using ``ROUND_HALF_UP``."""
+    result = currency.convert_price(1.0, "EUR")
+    assert result == 0.85


### PR DESCRIPTION
## Summary
- support currency conversion stored in Redis
- expose new helpers from shared package
- test currency conversion logic

## Testing
- `bash scripts/setup_codex.sh` *(fails: npm ERESOLVE)*
- `python -m pytest -W error backend/shared/tests/test_currency.py` *(fails: coverage below threshold)*
- `python -m pytest -W error` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687805e9087c83319e49b4c1c23f3782