### PR TITLE
Implement Timescale metrics storage

### DIFF
--- a/backend/monitoring/src/monitoring/metrics_store.py
+++ b/backend/monitoring/src/monitoring/metrics_store.py
@@ -1,0 +1,98 @@
+"""TimescaleDB storage for scores and publish latency metrics."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterator
+
+import psycopg2
+
+
+@dataclass
+class ScoreMetric:
+    """Score metric for a design idea."""
+
+    idea_id: int
+    timestamp: datetime
+    score: float
+
+
+@dataclass
+class PublishLatencyMetric:
+    """Publish latency metric for a design idea."""
+
+    idea_id: int
+    timestamp: datetime
+    latency_seconds: float
+
+
+class TimescaleMetricsStore:
+    """Store and downsample metrics in TimescaleDB."""
+
+    def __init__(self, db_url: str | None = None) -> None:
+        """Initialize the store and ensure tables exist."""
+        self.db_url = db_url or os.environ.get(
+            "METRICS_DB_URL", "postgresql://localhost/metrics"
+        )
+        with self._get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS scores (idea_id INTEGER, "
+                    "timestamp TIMESTAMPTZ, score DOUBLE PRECISION)"
+                )
+            )
+            cur.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS publish_latency (idea_id "
+                    "INTEGER, timestamp TIMESTAMPTZ, latency_seconds DOUBLE "
+                    "PRECISION)"
+                )
+            )
+            conn.commit()
+
+    @contextmanager
+    def _get_conn(self) -> Iterator[psycopg2.extensions.connection]:
+        """Yield a database connection."""
+        conn = psycopg2.connect(self.db_url)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def add_score(self, metric: ScoreMetric) -> None:
+        """Insert a score metric row."""
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO scores VALUES (%s, %s, %s)",
+                    (metric.idea_id, metric.timestamp, metric.score),
+                )
+                conn.commit()
+
+    def add_latency(self, metric: PublishLatencyMetric) -> None:
+        """Insert a publish latency metric row."""
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO publish_latency VALUES (%s, %s, %s)",
+                    (metric.idea_id, metric.timestamp, metric.latency_seconds),
+                )
+                conn.commit()
+
+    def create_hourly_continuous_aggregate(self) -> None:
+        """Create an hourly downsampled view for latency metrics."""
+        stmt = (
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS latency_hourly "
+            "WITH (timescaledb.continuous) AS "
+            "SELECT time_bucket('1 hour', timestamp) AS bucket, "
+            "AVG(latency_seconds) AS avg_latency "
+            "FROM publish_latency GROUP BY bucket"
+        )
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(stmt)
+                conn.commit()

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ The `blueprints` folder contains the full system blueprint.
 - [Design Idea Engine Complete Blueprint](blueprints/DesignIdeaEngineCompleteBlueprint.md)
 - [Sphinx Documentation](sphinx/index)
 - [Configuration](configuration.md)
+- [Metrics Storage](metrics_storage.md)
 
 The `scripts` directory provides helper scripts for setting up storage and CDN resources:
 

--- a/docs/metrics_storage.md
+++ b/docs/metrics_storage.md
@@ -1,0 +1,18 @@
+# Metrics Storage with TimescaleDB
+
+This project stores publish latency and scoring metrics in **TimescaleDB** for efficient time-series queries.
+
+1. Run TimescaleDB and configure `METRICS_DB_URL` to point to the instance.
+2. The monitoring service uses `TimescaleMetricsStore` to insert `scores` and `publish_latency` records.
+3. Downsample data with a continuous aggregate view:
+
+```sql
+CREATE MATERIALIZED VIEW IF NOT EXISTS latency_hourly
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', timestamp) AS bucket,
+       AVG(latency_seconds) AS avg_latency
+FROM publish_latency
+GROUP BY bucket;
+```
+
+Visualize trends in Grafana by connecting to TimescaleDB and building dashboards from the `scores` and `latency_hourly` tables.

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -1,0 +1,28 @@
+"""Test the Timescale metrics storage utilities."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from backend.monitoring.src.monitoring.metrics_store import (
+    PublishLatencyMetric,
+    ScoreMetric,
+    TimescaleMetricsStore,
+)
+
+
+def test_metrics_insertion(tmp_path: Path) -> None:
+    """Verify that metrics can be stored without error."""
+    db = tmp_path / "metrics.db"
+    store = TimescaleMetricsStore(f"sqlite:///{db}")
+    score_metric = ScoreMetric(
+        idea_id=1, timestamp=datetime.now(timezone.utc), score=0.8
+    )
+    store.add_score(score_metric)
+    latency_metric = PublishLatencyMetric(
+        idea_id=1,
+        timestamp=datetime.now(timezone.utc),
+        latency_seconds=2.5,
+    )
+    store.add_latency(latency_metric)
+    # create aggregate should not fail on SQLite
+    store.create_hourly_continuous_aggregate()


### PR DESCRIPTION
## Summary
- document metrics storage plan
- link to metrics storage docs in documentation overview
- implement TimescaleMetricsStore utility
- add basic unit test for metrics store

## Testing
- `flake8 backend/monitoring/src/monitoring/metrics_store.py tests/test_metrics_store.py`
- `mypy backend/monitoring/src/monitoring/metrics_store.py tests/test_metrics_store.py`
- `npm run lint` *(fails: Expected 'undefined' and instead saw 'void')*
- `python -m pytest -W error` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6878086700048331b8767c193203423a