### PR TITLE
Enable env-based tracing setup

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import os
 import uuid
 from typing import Any, Callable, Coroutine, Dict, Iterable
 
@@ -25,9 +26,10 @@ from backend.shared import add_error_handlers, configure_sentry
 configure_logging()
 logger = logging.getLogger(__name__)
 
+SERVICE_NAME = os.getenv("SERVICE_NAME", "analytics")
 app = FastAPI(title="Analytics Service")
-configure_tracing(app, "analytics")
-configure_sentry(app, "analytics")
+configure_tracing(app, SERVICE_NAME)
+configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -1,6 +1,7 @@
 """API Gateway FastAPI application."""
 
 import logging
+import os
 import uuid
 from typing import Callable, Coroutine
 
@@ -17,10 +18,11 @@ from backend.shared import add_error_handlers, configure_sentry
 configure_logging()
 logger = logging.getLogger(__name__)
 
+SERVICE_NAME = os.getenv("SERVICE_NAME", "api-gateway")
 app = FastAPI(title="API Gateway")
 app.add_middleware(GZipMiddleware, minimum_size=1000)
-configure_tracing(app, "api-gateway")
-configure_sentry(app, "api-gateway")
+configure_tracing(app, SERVICE_NAME)
+configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 

--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
+import os
 import uuid
 from typing import Callable, Coroutine, List
 
@@ -20,9 +21,10 @@ from .storage import MetricsStore
 configure_logging()
 logger = logging.getLogger(__name__)
 
+SERVICE_NAME = os.getenv("SERVICE_NAME", "optimization")
 app = FastAPI(title="Optimization Service")
-configure_tracing(app, "optimization")
-configure_sentry(app, "optimization")
+configure_tracing(app, SERVICE_NAME)
+configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
 

--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -50,9 +50,10 @@ from .weight_repository import get_weights, update_weights
 configure_logging()
 logger = logging.getLogger(__name__)
 
+SERVICE_NAME = os.getenv("SERVICE_NAME", "scoring-engine")
 app = Flask(__name__)
-configure_tracing(app, "scoring-engine")
-configure_sentry(app, "scoring-engine")
+configure_tracing(app, SERVICE_NAME)
+configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_flask_error_handlers(app)
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")

--- a/tests/test_tracing_profiling.py
+++ b/tests/test_tracing_profiling.py
@@ -1,0 +1,79 @@
+import importlib
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from opentelemetry import trace
+from fastapi.testclient import TestClient
+
+SERVICES = [
+    (
+        "backend/api-gateway/src",
+        "api_gateway.main",
+        "fastapi",
+    ),
+    (
+        "backend/analytics",
+        "backend.analytics.api",
+        "fastapi",
+    ),
+    (
+        "backend/optimization",
+        "backend.optimization.api",
+        "fastapi",
+    ),
+    (
+        "backend/service-template/src",
+        "main",
+        "fastapi",
+    ),
+    (
+        "backend/signal-ingestion/src",
+        "signal_ingestion.main",
+        "fastapi",
+    ),
+    (
+        "backend/monitoring/src",
+        "monitoring.main",
+        "fastapi",
+    ),
+    (
+        "backend/marketplace-publisher/src",
+        "marketplace_publisher.main",
+        "fastapi",
+    ),
+    (
+        "backend/scoring-engine/scoring_engine",
+        "scoring_engine.app",
+        "flask",
+    ),
+]
+
+
+@pytest.mark.parametrize("base,module,framework", SERVICES)
+def test_tracing_and_profiling(
+    base: str, module: str, framework: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Ensure tracing and profiling middleware are configured."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / base))
+    os.environ["SERVICE_NAME"] = "test-service"
+    mod = importlib.import_module(module)
+    importlib.reload(mod)
+    app = getattr(mod, "app")
+
+    caplog.set_level(logging.INFO)
+    if framework == "fastapi":
+        client = TestClient(app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+    else:
+        app.config.update(TESTING=True)
+        client = app.test_client()
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    assert any("request timing" in record.getMessage() for record in caplog.records)
+    provider = trace.get_tracer_provider()
+    assert provider.resource.attributes.get("service.name") == "test-service"


### PR DESCRIPTION
## Summary
- load service name from `SERVICE_NAME` env var for tracing
- add tests for tracing and profiling middleware across services

## Testing
- `flake8`
- `mypy backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py tests/test_tracing_profiling.py`
- `pydocstyle backend/api-gateway/src/api_gateway/main.py backend/analytics/api.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py tests/test_tracing_profiling.py`
- `pytest tests/test_tracing_profiling.py -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_68792deebdcc833196c692767dee325c