### PR TITLE
Add Unleash feature flag caching

### DIFF
--- a/backend/shared/feature_flags.py
+++ b/backend/shared/feature_flags.py
@@ -1,20 +1,37 @@
-"""Feature flag utilities using Unleash."""
+"""Feature flag utilities using Unleash with simple caching.
+
+Flags are read from an Unleash server when configuration is available. Results
+are cached for ``UNLEASH_CACHE_TTL`` seconds and fall back to values defined in
+``UNLEASH_DEFAULTS`` (JSON mapping from flag names to booleans) when Unleash is
+disabled or errors occur.
+"""
 
 from __future__ import annotations
 
+import json
 import os
+import time
 from typing import Any
 
 from UnleashClient import UnleashClient
 
 _client: UnleashClient | None = None
+_cache: dict[str, tuple[bool, float]] = {}
+_cache_ttl: int = 30
+_defaults: dict[str, bool] = {}
 
 
 def initialize() -> None:
     """Initialize the global Unleash client if configuration is present."""
-    global _client  # noqa: PLW0603
+    global _client, _cache_ttl, _defaults  # noqa: PLW0603
     if _client is not None:
         return
+    defaults_env = os.getenv("UNLEASH_DEFAULTS", "{}")
+    try:
+        _defaults = {k: bool(v) for k, v in json.loads(defaults_env).items()}
+    except json.JSONDecodeError:
+        _defaults = {}
+    _cache_ttl = int(os.getenv("UNLEASH_CACHE_TTL", "30"))
     url = os.getenv("UNLEASH_URL")
     token = os.getenv("UNLEASH_API_TOKEN")
     app_name = os.getenv("UNLEASH_APP_NAME", "desainz")
@@ -27,9 +44,26 @@ def initialize() -> None:
 
 def is_enabled(name: str, context: dict[str, Any] | None = None) -> bool:
     """Return ``True`` if the feature ``name`` is enabled."""
+    cached = _cache.get(name)
+    now = time.monotonic()
+    if cached and cached[1] > now:
+        return cached[0]
+
+    default = _defaults.get(name, False)
+
+    def _fallback(_: str, __: dict[str, Any]) -> bool:
+        return default
+
     if _client is None:
-        return False
-    return _client.is_enabled(name, context or {})
+        result = default
+    else:
+        try:
+            result = _client.is_enabled(name, context or {}, _fallback)
+        except Exception:
+            result = default
+
+    _cache[name] = (result, now + _cache_ttl)
+    return result
 
 
 def shutdown() -> None:

--- a/backend/shared/tests/test_feature_flags.py
+++ b/backend/shared/tests/test_feature_flags.py
@@ -1,0 +1,54 @@
+"""Tests for feature flag utilities."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Iterator
+from unittest import mock
+
+import pytest
+
+from backend.shared import feature_flags
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def reload_module() -> Iterator[None]:
+    """Reload feature_flags module after each test."""
+    yield
+    importlib.reload(feature_flags)
+
+
+def test_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flags fall back to defaults when Unleash is disabled."""
+    monkeypatch.delenv("UNLEASH_URL", raising=False)
+    monkeypatch.delenv("UNLEASH_API_TOKEN", raising=False)
+    monkeypatch.setenv("UNLEASH_DEFAULTS", '{"demo": true}')
+    feature_flags.initialize()
+    assert feature_flags.is_enabled("demo") is True
+    assert feature_flags.is_enabled("missing") is False
+
+
+def test_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Calls to Unleash are cached for the configured TTL."""
+    monkeypatch.setenv("UNLEASH_URL", "http://example.com")
+    monkeypatch.setenv("UNLEASH_API_TOKEN", "tkn")
+    monkeypatch.setenv("UNLEASH_CACHE_TTL", "60")
+    client = mock.MagicMock()
+    client.is_enabled.return_value = True
+    monkeypatch.setattr(feature_flags, "UnleashClient", lambda **_: client)
+    feature_flags.initialize()
+    assert feature_flags.is_enabled("flag") is True
+    assert feature_flags.is_enabled("flag") is True
+    client.is_enabled.assert_called_once()
+
+
+def test_error_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Errors from Unleash return the configured default."""
+    monkeypatch.setenv("UNLEASH_URL", "http://example.com")
+    monkeypatch.setenv("UNLEASH_API_TOKEN", "tkn")
+    monkeypatch.setenv("UNLEASH_DEFAULTS", '{"flag": false}')
+    client = mock.MagicMock()
+    client.is_enabled.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(feature_flags, "UnleashClient", lambda **_: client)
+    feature_flags.initialize()
+    assert feature_flags.is_enabled("flag") is False

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -9,6 +9,10 @@ Experimental features are toggled using [Unleash](https://www.getunleash.io/).
 3. Optionally set `UNLEASH_APP_NAME` to override the default application name.
 4. Restart the service to load the flag configuration.
 
+Set ``UNLEASH_DEFAULTS`` to a JSON mapping of fallback values when no Unleash
+server is configured or if it cannot be reached. Results are cached for the
+number of seconds specified by ``UNLEASH_CACHE_TTL`` (default ``30``).
+
 ## Disabling a flag
 
 Disable the feature from the Unleash dashboard or remove the environment


### PR DESCRIPTION
## Summary
- support fallback values and caching for feature flags
- document UNLEASH_DEFAULTS and UNLEASH_CACHE_TTL
- add unit tests mocking Unleash

## Testing
- `python -m pytest -c /tmp/pytest_no_cov.ini backend/shared/tests/test_feature_flags.py`

------
https://chatgpt.com/codex/tasks/task_b_6879307c803c833188a94dff14ab28d4