### PR TITLE
Add performance metrics tables

### DIFF
--- a/backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py
@@ -1,0 +1,49 @@
+"""Add tables for score and latency metrics."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create score_metrics and publish_latency_metrics tables."""
+    op.create_table(
+        "score_metrics",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("idea_id", sa.Integer, sa.ForeignKey("ideas.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("score", sa.Float(), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_score_metrics_idea_id"), "score_metrics", ["idea_id"], unique=False
+    )
+    op.create_table(
+        "publish_latency_metrics",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("idea_id", sa.Integer, sa.ForeignKey("ideas.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("latency_seconds", sa.Float(), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_publish_latency_metrics_idea_id"),
+        "publish_latency_metrics",
+        ["idea_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop performance metric tables."""
+    op.drop_index(
+        op.f("ix_publish_latency_metrics_idea_id"),
+        table_name="publish_latency_metrics",
+    )
+    op.drop_table("publish_latency_metrics")
+    op.drop_index(op.f("ix_score_metrics_idea_id"), table_name="score_metrics")
+    op.drop_table("score_metrics")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -157,3 +157,29 @@ class AIModel(Base):
     details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     is_default: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class ScoreMetric(Base):
+    """Score metric for a design idea."""
+
+    __tablename__ = "score_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    idea_id: Mapped[int] = mapped_column(ForeignKey("ideas.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    score: Mapped[float] = mapped_column(Float)
+
+    idea: Mapped[Idea] = relationship()
+
+
+class PublishLatencyMetric(Base):
+    """Publish latency metric for a design idea."""
+
+    __tablename__ = "publish_latency_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    idea_id: Mapped[int] = mapped_column(ForeignKey("ideas.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    latency_seconds: Mapped[float] = mapped_column(Float)
+
+    idea: Mapped[Idea] = relationship()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,29 @@
+"""Tests for Alembic migrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+def test_scoring_engine_migrations(tmp_path: Path) -> None:
+    """Apply and revert scoring engine migrations without errors."""
+    db_path = tmp_path / "test.db"
+    cfg = Config("backend/shared/db/alembic_scoring_engine.ini")
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    insp = inspect(engine)
+    assert "score_metrics" in insp.get_table_names()
+    assert "publish_latency_metrics" in insp.get_table_names()
+
+    command.downgrade(cfg, "base")
+
+    insp = inspect(engine)
+    assert "score_metrics" not in insp.get_table_names()
+    assert "publish_latency_metrics" not in insp.get_table_names()


### PR DESCRIPTION
## Summary
- extend SQLAlchemy models with `ScoreMetric` and `PublishLatencyMetric`
- add Alembic migration for new tables
- test migrations upgrade and downgrade

## Testing
- `flake8 backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py tests/test_migrations.py`
- `mypy backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py tests/test_migrations.py --follow-imports=skip --ignore-missing-imports --allow-subclassing-any`
- `pydocstyle backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py tests/test_migrations.py`
- `docformatter -i backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py tests/test_migrations.py`
- `black backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0007_add_performance_metrics_tables.py tests/test_migrations.py`
- `pytest -W error` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_68793a82d59c833198092aac168904ac