### PR TITLE
Implement OAuth API clients

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/clients.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/clients.py
@@ -1,31 +1,73 @@
-"""Marketplace API clients with Selenium fallback."""
+"""Marketplace API clients with Selenium fallback and OAuth support."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
+import os
 import requests
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
-import os
 
 from .db import Marketplace
 
 
 class BaseClient:
-    """Base class for marketplace API clients."""
+    """Base class for marketplace API clients with OAuth helpers."""
 
-    def __init__(self, base_url: str) -> None:
-        """Store the base URL for the API."""
+    def __init__(
+        self,
+        base_url: str,
+        token_url: str | None = None,
+        client_id_env: str | None = None,
+        client_secret_env: str | None = None,
+        api_key_env: str | None = None,
+    ) -> None:
+        """Initialize API configuration and credentials."""
         self.base_url = base_url.rstrip("/")
+        self.token_url = token_url
+        self._client_id = os.getenv(client_id_env or "")
+        self._client_secret = os.getenv(client_secret_env or "")
+        self._api_key = os.getenv(api_key_env or "")
+        self._token: str | None = None
+
+    def _get_token(self) -> str | None:
+        """Retrieve an OAuth token if configuration is provided."""
+        if self._token:
+            return self._token
+        if self.token_url and self._client_id and self._client_secret:
+            response = requests.post(
+                self.token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            self._token = response.json().get("access_token")
+            return self._token
+        return None
 
     def publish_design(self, design_path: Path, metadata: dict[str, Any]) -> str:
-        """Upload design to the marketplace API and return listing ID."""
-        files = {"file": open(design_path, "rb")}
-        response = requests.post(
-            f"{self.base_url}/publish", files=files, data=metadata, timeout=30
-        )
+        """Upload a design and return the created listing ID."""
+        headers = {}
+        token = self._get_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if self._api_key:
+            headers["X-API-Key"] = self._api_key
+        with open(design_path, "rb") as file:
+            files = {"file": file}
+            response = requests.post(
+                f"{self.base_url}/publish",
+                files=files,
+                data=metadata,
+                headers=headers,
+                timeout=30,
+            )
         response.raise_for_status()
         data = response.json()
         return str(data["id"])
@@ -35,32 +77,56 @@ class RedbubbleClient(BaseClient):
     """Client for the Redbubble API."""
 
     def __init__(self) -> None:
-        """Initialize the API endpoint."""
-        super().__init__("https://api.redbubble.com")
+        """Configure endpoints and credentials from the environment."""
+        super().__init__(
+            "https://api.redbubble.com/v1",
+            os.getenv("REDBUBBLE_TOKEN_URL"),
+            "REDBUBBLE_CLIENT_ID",
+            "REDBUBBLE_CLIENT_SECRET",
+            "REDBUBBLE_API_KEY",
+        )
 
 
 class AmazonMerchClient(BaseClient):
     """Client for the Amazon Merch API."""
 
     def __init__(self) -> None:
-        """Initialize the API endpoint."""
-        super().__init__("https://api.amazonmerch.com")
+        """Configure endpoints and credentials from the environment."""
+        super().__init__(
+            "https://api.amazonmerch.com/v1",
+            os.getenv("AMAZON_MERCH_TOKEN_URL"),
+            "AMAZON_MERCH_CLIENT_ID",
+            "AMAZON_MERCH_CLIENT_SECRET",
+            "AMAZON_MERCH_API_KEY",
+        )
 
 
 class EtsyClient(BaseClient):
     """Client for the Etsy API."""
 
     def __init__(self) -> None:
-        """Initialize the API endpoint."""
-        super().__init__("https://api.etsy.com")
+        """Configure endpoints and credentials from the environment."""
+        super().__init__(
+            "https://api.etsy.com/v3",
+            os.getenv("ETSY_TOKEN_URL"),
+            "ETSY_CLIENT_ID",
+            "ETSY_CLIENT_SECRET",
+            "ETSY_API_KEY",
+        )
 
 
 class Society6Client(BaseClient):
     """Client for the Society6 API."""
 
     def __init__(self) -> None:
-        """Initialize the API endpoint."""
-        super().__init__("https://api.society6.com")
+        """Configure endpoints and credentials from the environment."""
+        super().__init__(
+            "https://api.society6.com/v1",
+            os.getenv("SOCIETY6_TOKEN_URL"),
+            "SOCIETY6_CLIENT_ID",
+            "SOCIETY6_CLIENT_SECRET",
+            "SOCIETY6_API_KEY",
+        )
 
 
 class SeleniumFallback:

--- a/backend/marketplace-publisher/tests/test_clients.py
+++ b/backend/marketplace-publisher/tests/test_clients.py
@@ -1,0 +1,78 @@
+"""Tests for OAuth-enabled marketplace clients."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+import os
+
+import pytest
+import requests
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+from marketplace_publisher import clients
+
+
+def _setup_env(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
+    """Set environment variables for a client."""
+    monkeypatch.setenv(f"{prefix}_CLIENT_ID", "id")
+    monkeypatch.setenv(f"{prefix}_CLIENT_SECRET", "secret")
+    monkeypatch.setenv(f"{prefix}_TOKEN_URL", "https://example.com/token")
+    monkeypatch.setenv(f"{prefix}_API_KEY", "key")
+
+
+@pytest.mark.parametrize(
+    "client_cls,prefix,publish_url",
+    [
+        (clients.RedbubbleClient, "REDBUBBLE", "https://api.redbubble.com/v1/publish"),
+        (
+            clients.AmazonMerchClient,
+            "AMAZON_MERCH",
+            "https://api.amazonmerch.com/v1/publish",
+        ),
+        (clients.EtsyClient, "ETSY", "https://api.etsy.com/v3/publish"),
+        (clients.Society6Client, "SOCIETY6", "https://api.society6.com/v1/publish"),
+    ],
+)
+def test_publish_design_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    client_cls: Callable[[], clients.BaseClient],
+    prefix: str,
+    publish_url: str,
+) -> None:
+    """Ensure clients fetch tokens and attach auth headers."""
+
+    _setup_env(monkeypatch, prefix)
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_post(url: str, *args: Any, **kwargs: Any) -> Any:
+        calls.append((url, kwargs))
+
+        class Resp:
+            def __init__(self, data: dict[str, Any]) -> None:
+                self._data = data
+
+            def raise_for_status(self) -> None:  # noqa: D401
+                """No-op to simulate successful request."""
+
+            def json(self) -> dict[str, Any]:
+                return self._data
+
+        if url == "https://example.com/token":
+            return Resp({"access_token": "tok"})
+        assert kwargs["headers"]["Authorization"] == "Bearer tok"
+        assert kwargs["headers"]["X-API-Key"] == "key"
+        return Resp({"id": 1})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    design = tmp_path / "d.png"
+    design.write_text("x")
+    client = client_cls()
+    listing_id = client.publish_design(design, {"title": "t"})
+
+    assert listing_id == "1"
+    assert calls[0][0] == "https://example.com/token"
+    assert calls[1][0] == publish_url


### PR DESCRIPTION
## Summary
- implement marketplace API clients with OAuth and API key handling
- add test coverage for the clients with mocked requests

## Testing
- `mypy --ignore-missing-imports --follow-imports=skip backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/tests/test_clients.py`
- `flake8 backend/marketplace-publisher/src/marketplace_publisher/clients.py backend/marketplace-publisher/tests/test_clients.py`
- `pytest backend/marketplace-publisher/tests/test_clients.py -W error --cov=backend/marketplace-publisher/src/marketplace_publisher/clients.py --cov-fail-under=0` *(fails: Coverage failure: total of 24 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_b_68793aa7adfc8331af95dd490fb81fd2