### PR TITLE
Add GPU slot locking with Redis

### DIFF
--- a/backend/mockup-generation/tests/test_gpu_lock.py
+++ b/backend/mockup-generation/tests/test_gpu_lock.py
@@ -1,0 +1,31 @@
+"""Tests for GPU slot locking."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import types  # noqa: E402
+
+diffusers_mod = types.ModuleType("diffusers")
+diffusers_mod.StableDiffusionXLPipeline = object  # type: ignore[attr-defined]
+sys.modules.setdefault("diffusers", diffusers_mod)
+sys.modules.setdefault("torch", types.ModuleType("torch"))
+
+import fakeredis  # noqa: E402
+import pytest  # noqa: E402
+
+from mockup_generation import tasks  # noqa: E402
+
+
+def test_gpu_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lock is acquired and released using the context manager."""
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(tasks, "redis_client", fake)
+    monkeypatch.setattr(tasks, "GPU_SLOTS", 1)
+
+    with tasks.gpu_slot():
+        assert fake.lock("gpu_slot:0").locked()
+    assert not fake.lock("gpu_slot:0").locked()


### PR DESCRIPTION
## Summary
- manage GPU slot allocation in `mockup_generation.tasks`
- include a simple test verifying GPU lock behaviour

## Testing
- `mypy backend/mockup-generation/tests/test_gpu_lock.py --ignore-missing-imports`
- `flake8 backend/mockup-generation/tests/test_gpu_lock.py`
- `docformatter --check backend/mockup-generation/tests/test_gpu_lock.py`
- `pydocstyle backend/mockup-generation/tests/test_gpu_lock.py`
- `pytest backend/mockup-generation/tests/test_gpu_lock.py -W error` *(fails: ModuleNotFoundError: No module named 'diffusers')*

------
https://chatgpt.com/codex/tasks/task_b_68793a99f73c833197b02eda10996265