### PR TITLE
Implement bloom filter init and TTL

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/dedup.py
+++ b/backend/signal-ingestion/src/signal_ingestion/dedup.py
@@ -4,15 +4,30 @@ from __future__ import annotations
 
 import redis
 
+from .settings import settings
+
 redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
 BLOOM_KEY = "signals:bloom"
 
 
+def initialize() -> None:
+    """Create the bloom filter if it does not already exist."""
+    if not redis_client.exists(BLOOM_KEY):
+        redis_client.bf().create(
+            BLOOM_KEY, settings.dedup_error_rate, settings.dedup_capacity
+        )
+        redis_client.expire(BLOOM_KEY, settings.dedup_ttl)
+
+
 def is_duplicate(key: str) -> bool:
-    """Return True if ``key`` already exists in the bloom filter."""
-    return bool(redis_client.bfExists(BLOOM_KEY, key))
+    """Return ``True`` if ``key`` already exists in the bloom filter."""
+    return bool(redis_client.bf().exists(BLOOM_KEY, key))
 
 
 def add_key(key: str) -> None:
-    """Add ``key`` to the bloom filter."""
-    redis_client.bfAdd(BLOOM_KEY, key)
+    """Add ``key`` to the bloom filter and refresh TTL."""
+    redis_client.bf().add(BLOOM_KEY, key)
+    redis_client.expire(BLOOM_KEY, settings.dedup_ttl)
+
+
+initialize()

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -13,6 +13,9 @@ class Settings(BaseSettings):
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"
     signal_retention_days: int = 90
+    dedup_error_rate: float = 0.01
+    dedup_capacity: int = 100_000
+    dedup_ttl: int = 86_400
 
 
 settings = Settings()

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -10,6 +10,14 @@ Incoming signal data is sanitized by `signal_ingestion.privacy.purge_row`, which
 
 Signals older than the configured `signal_retention_days` setting (default: 90 days) are removed by `signal_ingestion.retention.purge_old_signals`. Analytics logs should be pruned on the same schedule.
 
+## Deduplication
+
+`signal_ingestion.dedup` uses a Redis Bloom filter to avoid processing duplicates.
+The filter is created on startup with the error rate specified by the
+`dedup_error_rate` setting (default: `0.01`).
+Entries remain for the number of seconds configured by `dedup_ttl` (default:
+`86400` seconds).
+
 ## Compliance Steps
 
 1. Set the retention period in the environment if different from the default.


### PR DESCRIPTION
## Summary
- create bloom filter in signal ingestion startup with configurable error rate
- refresh bloom filter TTL on key addition
- document new deduplication settings

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/dedup.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/dedup.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/dedup.py backend/signal-ingestion/src/signal_ingestion/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose', MissingGreenlet)*

------
https://chatgpt.com/codex/tasks/task_b_687943dccff08331bb97bb6fa9095079