### PR TITLE
Add webhook endpoint for marketplace callbacks

### DIFF
--- a/openapi/marketplace-publisher.json
+++ b/openapi/marketplace-publisher.json
@@ -135,6 +135,58 @@
           }
         }
       }
+    },
+    "/webhooks/{marketplace}": {
+      "post": {
+        "summary": "Webhook",
+        "description": "Receive status callbacks from marketplaces.",
+        "operationId": "webhook_webhooks__marketplace__post",
+        "parameters": [
+          {
+            "name": "marketplace",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Marketplace"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -220,6 +272,25 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "WebhookPayload": {
+        "type": "object",
+        "properties": {
+          "task_id": {
+            "type": "integer",
+            "title": "Task Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "required": [
+          "task_id",
+          "status"
+        ],
+        "title": "WebhookPayload",
+        "description": "Webhook callback payload."
       }
     }
   }

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,65 @@
+"""Tests for webhook handling in marketplace publisher."""
+
+from __future__ import annotations
+
+import sys
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+os.environ.setdefault("PYTHONWARNINGS", "ignore::DeprecationWarning")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "backend" / "marketplace-publisher" / "src"))  # noqa: E402
+sys.path.append(str(ROOT))  # noqa: E402
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"  # noqa: E402
+os.environ["SELENIUM_SKIP"] = "1"  # noqa: E402
+
+from marketplace_publisher import db  # noqa: E402
+from marketplace_publisher import main  # noqa: E402
+
+
+@pytest.mark.asyncio()
+async def test_webhook_updates_task_state(monkeypatch, tmp_path: Path) -> None:
+    """Posting to the webhook should update task status."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(db, "engine", engine)
+    monkeypatch.setattr(db, "SessionLocal", session_factory)
+    from datetime import datetime, UTC
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        db,
+        "datetime",
+        SimpleNamespace(utcnow=lambda: datetime.now(UTC)),
+    )
+    await db.init_db()
+
+    async with session_factory() as session:
+        now = datetime.now(UTC)
+        task = await db.create_task(
+            session,
+            marketplace=db.Marketplace.redbubble,
+            design_path="design.png",
+            created_at=now,
+            updated_at=now,
+        )
+
+    client = TestClient(main.app)
+    resp = client.post(
+        f"/webhooks/{db.Marketplace.redbubble.value}",
+        json={"task_id": task.id, "status": db.PublishStatus.success.value},
+    )
+    assert resp.status_code == 200
+
+    async with session_factory() as session:
+        refreshed = await db.get_task(session, task.id)
+        assert refreshed is not None
+        assert refreshed.status == db.PublishStatus.success


### PR DESCRIPTION
## Summary
- implement `/webhooks/{marketplace}` endpoint in publisher service
- update OpenAPI specification for webhook support
- add regression test for webhook handling

## Testing
- `mypy --config-file pyproject.toml backend/marketplace-publisher/src/marketplace_publisher/main.py tests/test_webhooks.py` *(fails: Library stubs not installed)*
- `pytest -q tests/test_webhooks.py` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_b_687943f2f08c8331ba83bb8aa67dea58