### PR TITLE
Add more PII patterns

### DIFF
--- a/backend/signal-ingestion/src/signal_ingestion/privacy.py
+++ b/backend/signal-ingestion/src/signal_ingestion/privacy.py
@@ -6,14 +6,42 @@ import re
 from typing import Any
 
 # Regex patterns for basic PII detection
+#
+# These patterns intentionally remain simple and do not aim to be
+# exhaustive. They cover the most common formats for PII found in
+# analytics payloads without incurring a noticeable performance hit.
 PII_PATTERNS = [
+    # Email addresses
     re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+    # US phone numbers
     re.compile(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b"),
+    # Simple street addresses (e.g. "123 Main St")
+    re.compile(
+        r"\b\d{1,5}\s+(?:[A-Za-z0-9.-]+\s)+(?:Street|St|Avenue|Ave|Road|Rd|"
+        r"Boulevard|Blvd|Lane|Ln)\b",
+        re.IGNORECASE,
+    ),
+    # Credit card numbers (13 to 16 digits allowing separators)
+    re.compile(r"\b(?:\d[ -]*?){13,16}\b"),
+    # Two capitalized words that could represent a name
+    re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+\b"),
 ]
 
 
 def purge_text(text: str) -> str:
-    """Remove PII substrings from ``text``."""
+    """
+    Remove PII substrings from ``text``.
+
+    Parameters
+    ----------
+    text:
+        Arbitrary text that may contain personally identifiable information.
+
+    Returns
+    -------
+    str
+        The sanitized text with all detected PII replaced by ``[REDACTED]``.
+    """
     result = text
     for pattern in PII_PATTERNS:
         result = pattern.sub("[REDACTED]", result)
@@ -21,5 +49,17 @@ def purge_text(text: str) -> str:
 
 
 def purge_row(row: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of ``row`` with any PII removed."""
+    """
+    Return a copy of ``row`` with any PII removed.
+
+    Parameters
+    ----------
+    row:
+        Mapping of column names to values from which PII should be stripped.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new dictionary with all string values sanitized.
+    """
     return {k: purge_text(v) if isinstance(v, str) else v for k, v in row.items()}

--- a/backend/signal-ingestion/tests/test_privacy.py
+++ b/backend/signal-ingestion/tests/test_privacy.py
@@ -15,3 +15,24 @@ def test_purge_row_removes_phone() -> None:
     row = {"content": "Call 123-456-7890 now"}
     cleaned = purge_row(row)
     assert "123-456-7890" not in cleaned["content"]
+
+
+def test_purge_row_removes_address() -> None:
+    """Ensure street addresses are stripped from content."""
+    row = {"content": "Meet me at 123 Main St"}
+    cleaned = purge_row(row)
+    assert "123 Main St" not in cleaned["content"]
+
+
+def test_purge_row_removes_credit_card() -> None:
+    """Ensure credit card numbers are stripped from content."""
+    row = {"content": "Card 4111 1111 1111 1111"}
+    cleaned = purge_row(row)
+    assert "4111 1111 1111 1111" not in cleaned["content"]
+
+
+def test_purge_row_removes_name() -> None:
+    """Ensure names are stripped from content."""
+    row = {"content": "Signed, John Smith"}
+    cleaned = purge_row(row)
+    assert "John Smith" not in cleaned["content"]


### PR DESCRIPTION
## Summary
- broaden PII detection with address, card and name patterns
- test new patterns

## Testing
- `flake8 backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/tests/test_privacy.py`
- `mypy backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/tests/test_privacy.py`
- `pydocstyle backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/tests/test_privacy.py`
- `docformatter -i backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/tests/test_privacy.py`
- `black backend/signal-ingestion/src/signal_ingestion/privacy.py backend/signal-ingestion/tests/test_privacy.py`
- `PYTEST_ADDOPTS='--cov=signal_ingestion.privacy --cov-report=term --cov-fail-under=80' python -m pytest backend/signal-ingestion/tests/test_privacy.py -W error` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_b_68794b55830c83319536e1bc9845f57b