### PR TITLE
Add Redis cache metrics

### DIFF
--- a/backend/scoring-engine/scoring_engine/app.py
+++ b/backend/scoring-engine/scoring_engine/app.py
@@ -20,6 +20,10 @@ from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
+
+# Cache metric keys
+CACHE_HIT_KEY = "cache_hits"
+CACHE_MISS_KEY = "cache_misses"
 from .scoring import Signal, calculate_score
 from .weight_repository import get_weights, update_weights, get_centroid
 from .centroid_job import start_centroid_scheduler
@@ -126,7 +130,9 @@ async def score_signal(payload: ScoreRequest) -> JSONResponse:
     key = json.dumps(payload.model_dump(), sort_keys=True)
     cached = await redis_client.get(key)
     if cached is not None:
+        await redis_client.incr(CACHE_HIT_KEY)
         return JSONResponse({"score": float(cached), "cached": True})
+    await redis_client.incr(CACHE_MISS_KEY)
     signal = Signal(
         timestamp=payload.timestamp,
         engagement_rate=payload.engagement_rate,
@@ -151,6 +157,16 @@ async def health() -> dict[str, str]:
 async def ready() -> dict[str, str]:
     """Return service readiness."""
     return {"status": "ready"}
+
+
+@app.get("/metrics")
+async def metrics() -> JSONResponse:
+    """Return cache hit/miss metrics stored in Redis."""
+    hits_raw = await redis_client.get(CACHE_HIT_KEY)
+    misses_raw = await redis_client.get(CACHE_MISS_KEY)
+    hits = int(hits_raw or 0)
+    misses = int(misses_raw or 0)
+    return JSONResponse({"cache_hits": hits, "cache_misses": misses})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/scoring-engine/tests/test_metrics.py
+++ b/backend/scoring-engine/tests/test_metrics.py
@@ -1,0 +1,41 @@
+"""Tests for cache metrics endpoint."""
+
+from datetime import datetime, timezone
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+import scoring_engine.app as scoring_module
+from scoring_engine.app import app
+from scoring_engine.weight_repository import update_weights
+
+
+def setup_module(module) -> None:
+    """Use fakeredis for tests."""
+    scoring_module.redis_client = fakeredis.aioredis.FakeRedis()
+
+
+def test_metrics_endpoint_counts_hits_and_misses() -> None:
+    """/metrics returns correct cache hit and miss counts."""
+    client = TestClient(app)
+    update_weights(
+        freshness=1.0,
+        engagement=1.0,
+        novelty=1.0,
+        community_fit=1.0,
+        seasonality=1.0,
+    )
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "engagement_rate": 1.0,
+        "embedding": [1.0, 0.0],
+    }
+    # first request miss
+    client.post("/score", json=payload)
+    # second request hit
+    client.post("/score", json=payload)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cache_hits"] == 1
+    assert data["cache_misses"] == 1

--- a/openapi/scoring-engine.json
+++ b/openapi/scoring-engine.json
@@ -80,6 +80,15 @@
           }
         }
       }
+    },
+    "/metrics": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -115,6 +115,7 @@ spec = {
         },
         "/health": {"get": {"responses": {"200": {"description": "OK"}}}},
         "/ready": {"get": {"responses": {"200": {"description": "Ready"}}}},
+        "/metrics": {"get": {"responses": {"200": {"description": "OK"}}}},
     },
     "components": {
         "schemas": {


### PR DESCRIPTION
## Summary
- track Redis cache hit/miss counts in scoring engine
- expose counts via new `/metrics` endpoint
- document `/metrics` in OpenAPI spec
- test cache metric behaviour

## Testing
- `make lint` *(fails: D104, E302, F401, ...)*
- `make test` *(fails: ModuleNotFoundError: No module named '...')*

------
https://chatgpt.com/codex/tasks/task_b_68794b58b9348331990d5c3f6b7db519