### PR TITLE
Add pricing adjustments for listings

### DIFF
--- a/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/pricing.py
@@ -1,0 +1,37 @@
+"""Pricing utilities for marketplace listings."""
+
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+from .db import Marketplace
+
+BASE_PRICE = 20.0
+SCORE_FACTOR = 0.1
+FEE_PERCENT: Mapping[Marketplace, float] = {
+    Marketplace.redbubble: 0.2,
+    Marketplace.amazon_merch: 0.3,
+    Marketplace.etsy: 0.15,
+    Marketplace.society6: 0.25,
+}
+
+
+def adjust_price(
+    score: float, marketplace: Marketplace, base_price: float = BASE_PRICE
+) -> float:
+    """Return final price including score adjustment and fees."""
+    adjusted = base_price * (1 + score * SCORE_FACTOR)
+    fee = FEE_PERCENT.get(marketplace, 0.0)
+    return round(adjusted * (1 + fee), 2)
+
+
+def create_listing_metadata(
+    score: float,
+    marketplace: Marketplace,
+    metadata: Mapping[str, Any] | None = None,
+    base_price: float = BASE_PRICE,
+) -> dict[str, Any]:
+    """Return listing metadata with computed price."""
+    data = dict(metadata or {})
+    data["price"] = adjust_price(score, marketplace, base_price)
+    return data

--- a/backend/marketplace-publisher/tests/test_pricing.py
+++ b/backend/marketplace-publisher/tests/test_pricing.py
@@ -1,0 +1,25 @@
+"""Tests for price adjustments."""
+
+import os
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"  # noqa: E402
+
+from marketplace_publisher.pricing import (  # noqa: E402
+    adjust_price,
+    create_listing_metadata,
+)
+from marketplace_publisher.db import Marketplace  # noqa: E402
+
+
+def test_adjust_price_includes_score_and_fee() -> None:
+    """Price scales with score and fee percentages."""
+    price_low = adjust_price(0.0, Marketplace.redbubble)
+    price_high = adjust_price(2.0, Marketplace.redbubble)
+    assert price_high > price_low
+
+
+def test_create_listing_metadata_adds_price() -> None:
+    """Computed price is added to metadata."""
+    metadata = create_listing_metadata(1.0, Marketplace.etsy, {"title": "t"})
+    assert "price" in metadata
+    assert metadata["price"] > 0


### PR DESCRIPTION
## Summary
- implement pricing utils for marketplace listings
- inject pricing into publish metadata
- test pricing logic and API integration

## Testing
- `python -m pytest -W error backend/marketplace-publisher/tests/test_pricing.py backend/marketplace-publisher/tests/test_api.py` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_b_68794b6042188331bcad3a6447065632