### PR TITLE
Add generated mockups tracking

### DIFF
--- a/backend/mockup-generation/tests/test_model_repository.py
+++ b/backend/mockup-generation/tests/test_model_repository.py
@@ -1,0 +1,98 @@
+"""Tests for generated mockup repository functions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import types
+
+root = Path(__file__).resolve().parents[3]
+sys.path.append(str(root))  # noqa: E402
+sys.path.append(str(root / "backend" / "mockup-generation"))  # noqa: E402
+
+fastapi_mod = types.ModuleType("fastapi")
+fastapi_mod.FastAPI = object
+fastapi_mod.Request = object
+fastapi_mod.Response = object
+fastapi_mod.HTTPException = Exception
+responses_mod = types.ModuleType("fastapi.responses")
+responses_mod.JSONResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)
+fastapi_mod.responses = responses_mod
+sys.modules.setdefault("fastapi", fastapi_mod)
+
+flask_mod = types.ModuleType("flask")
+flask_mod.Flask = object
+flask_mod.request = object()
+flask_mod.jsonify = lambda *args, **kwargs: ""
+sys.modules.setdefault("flask", flask_mod)
+
+otel_mod = types.ModuleType("opentelemetry")
+otel_mod.trace = object()
+sys.modules.setdefault("opentelemetry", otel_mod)
+
+fastapi_instr = types.ModuleType("opentelemetry.instrumentation.fastapi")
+fastapi_instr.FastAPIInstrumentor = object
+sys.modules.setdefault("opentelemetry.instrumentation.fastapi", fastapi_instr)
+
+flask_instr = types.ModuleType("opentelemetry.instrumentation.flask")
+flask_instr.FlaskInstrumentor = object
+sys.modules.setdefault("opentelemetry.instrumentation.flask", flask_instr)
+
+res_mod = types.ModuleType("opentelemetry.sdk.resources")
+res_mod.Resource = object
+sys.modules.setdefault("opentelemetry.sdk.resources", res_mod)
+
+trace_mod = types.ModuleType("opentelemetry.sdk.trace")
+trace_mod.TracerProvider = object
+sys.modules.setdefault("opentelemetry.sdk.trace", trace_mod)
+
+export_mod = types.ModuleType("opentelemetry.sdk.trace.export")
+export_mod.BatchSpanProcessor = object
+sys.modules.setdefault("opentelemetry.sdk.trace.export", export_mod)
+
+exp_http_mod = types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter")
+exp_http_mod.OTLPSpanExporter = object
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    exp_http_mod,
+)
+
+for name in [
+    "flask",
+    "opentelemetry",
+    "opentelemetry.sdk.resources",
+    "opentelemetry.sdk.trace",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "sentry_sdk",
+    "sentry_sdk.integrations.asgi",
+]:
+    sys.modules.setdefault(name, types.ModuleType(name))
+
+sentry_mod = sys.modules.setdefault("sentry_sdk", types.ModuleType("sentry_sdk"))
+sentry_mod.init = lambda *args, **kwargs: None
+sentry_asgi = sys.modules.setdefault(
+    "sentry_sdk.integrations.asgi", types.ModuleType("sentry_sdk.integrations.asgi")
+)
+sentry_asgi.SentryAsgiMiddleware = object
+logging_mod = sys.modules.setdefault(
+    "sentry_sdk.integrations.logging",
+    types.ModuleType("sentry_sdk.integrations.logging"),
+)
+logging_mod.LoggingIntegration = object
+
+from mockup_generation.model_repository import (  # noqa: E402
+    list_generated_mockups,
+    save_generated_mockup,
+)
+
+
+def test_save_and_list_generated_mockups() -> None:
+    """Insert a record and retrieve it."""
+    save_generated_mockup("a prompt", 10, 123)
+    items = list_generated_mockups()
+    assert any(
+        i.prompt == "a prompt" and i.num_inference_steps == 10 and i.seed == 123
+        for i in items
+    )

--- a/backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py
@@ -1,0 +1,30 @@
+"""Add generated_mockups table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create generated_mockups table."""
+    op.create_table(
+        "generated_mockups",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("prompt", sa.String(), nullable=False),
+        sa.Column("num_inference_steps", sa.Integer, nullable=False),
+        sa.Column("seed", sa.Integer, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop generated_mockups table."""
+    op.drop_table("generated_mockups")

--- a/backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py
@@ -1,0 +1,18 @@
+"""Merge heads after generated_mockups."""
+
+from __future__ import annotations
+
+revision = "0010"
+down_revision = ("0009", "0002")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge branches."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade merge revision."""
+    pass

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -196,3 +196,15 @@ class PublishLatencyMetric(Base):
     latency_seconds: Mapped[float] = mapped_column(Float)
 
     idea: Mapped[Idea] = relationship()
+
+
+class GeneratedMockup(Base):
+    """Parameters used for generating a mockup."""
+
+    __tablename__ = "generated_mockups"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    prompt: Mapped[str] = mapped_column(String)
+    num_inference_steps: Mapped[int] = mapped_column(Integer)
+    seed: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- track generation parameters in `generated_mockups` table
- add alembic migrations
- expose helpers in `model_repository`
- test insert and retrieval logic

## Testing
- `flake8 backend/shared/db/models.py backend/mockup-generation/mockup_generation/model_repository.py backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py backend/mockup-generation/tests/test_model_repository.py`
- `black backend/shared/db/models.py backend/mockup-generation/mockup_generation/model_repository.py backend/shared/db/migrations/scoring_engine/versions/0009_add_generated_mockups_table.py backend/shared/db/migrations/scoring_engine/versions/0010_merge_heads.py backend/mockup-generation/tests/test_model_repository.py`
- `mypy backend/mockup-generation/mockup_generation/model_repository.py backend/shared/db/models.py --ignore-missing-imports` *(fails: Unused "type: ignore" comment, Missing library stubs, etc.)*
- `bash scripts/validate_migrations.sh` *(fails: Multiple migration heads detected)*
- `pytest backend/mockup-generation/tests/test_model_repository.py` *(fails: ModuleNotFoundError: No module named 'redis')*
- `sphinx-build -b html docs docs/_build/html` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68794b5d6af08331b9f453e0601bbbe8