### PR TITLE
Implement tRPC proxy

### DIFF
--- a/backend/api-gateway/tests/test_routes.py
+++ b/backend/api-gateway/tests/test_routes.py
@@ -6,9 +6,12 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
+import httpx  # noqa: E402
 
 from api_gateway.main import app  # noqa: E402
 from api_gateway.auth import create_access_token  # noqa: E402
+from types import TracebackType  # noqa: E402
+from typing import Any, Optional, Type  # noqa: E402
 
 client = TestClient(app)
 
@@ -20,9 +23,40 @@ def test_status() -> None:
     assert response.json() == {"status": "ok"}
 
 
-def test_trpc_ping() -> None:
-    """TRPC ping should return pong."""
+import pytest  # noqa: E402
+
+
+def test_trpc_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Proxy tRPC ping to backend service."""
     token = create_access_token({"sub": "tester"})
+
+    class MockClient:
+        async def __aenter__(self) -> "MockClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Optional[TracebackType],
+        ) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            json: Any | None = None,
+            headers: dict[str, str] | None = None,
+        ) -> httpx.Response:
+            assert url.endswith("/trpc/ping")
+            assert headers == {"Authorization": f"Bearer {token}"}
+            return httpx.Response(
+                200,
+                json={"result": {"message": "pong", "user": "tester"}},
+            )
+
+    monkeypatch.setattr("api_gateway.routes.TRPC_SERVICE_URL", "http://backend:8000")
+    monkeypatch.setattr(httpx, "AsyncClient", MockClient)
     response = client.post(
         "/trpc/ping",
         headers={"Authorization": f"Bearer {token}"},


### PR DESCRIPTION
## Summary
- proxy tRPC calls from the API Gateway to backend services
- unit test tRPC ping via FastAPI `TestClient`

## Testing
- `python -m flake8 backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_routes.py`
- `python -m black backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_routes.py --check`
- `python -m pydocstyle backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_routes.py`
- `docformatter --check backend/api-gateway/src/api_gateway/routes.py backend/api-gateway/tests/test_routes.py`
- `python -m mypy backend/api-gateway/tests/test_routes.py`
- `python -m pytest -W error backend/api-gateway/tests/test_routes.py::test_trpc_ping -vv` *(fails: ModuleNotFoundError: No module named 'mockup_generation')*

------
https://chatgpt.com/codex/tasks/task_b_6879527d017083318935421e85677cc8