### PR TITLE
Add marketplace metrics ingestion

### DIFF
--- a/backend/feedback-loop/feedback_loop/__init__.py
+++ b/backend/feedback-loop/feedback_loop/__init__.py
@@ -3,7 +3,12 @@
 from .ab_testing import ABTestManager, BudgetAllocation
 from .scheduler import setup_scheduler
 from .weight_updater import update_weights
-from .ingestion import ingest_metrics
+from .ingestion import (
+    ingest_metrics,
+    fetch_marketplace_metrics,
+    store_marketplace_metrics,
+    schedule_marketplace_ingestion,
+)
 
 __all__ = [
     "ABTestManager",
@@ -11,4 +16,7 @@ __all__ = [
     "setup_scheduler",
     "update_weights",
     "ingest_metrics",
+    "fetch_marketplace_metrics",
+    "store_marketplace_metrics",
+    "schedule_marketplace_ingestion",
 ]

--- a/backend/feedback-loop/feedback_loop/ingestion.py
+++ b/backend/feedback-loop/feedback_loop/ingestion.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Iterable, Mapping
+
+import requests
+from apscheduler.job import Job
+from apscheduler.schedulers.base import BaseScheduler
 
 import pandas as pd
+from backend.shared.db import session_scope
+from backend.shared.db import models
 
 logger = logging.getLogger(__name__)
 
@@ -18,3 +24,64 @@ def ingest_metrics(metrics: Iterable[dict[str, float]]) -> pd.DataFrame:
         df["timestamp"] = datetime.now(timezone.utc)
     logger.info("ingested %s metrics", len(df))
     return df
+
+
+def fetch_marketplace_metrics(
+    api_url: str, listing_ids: Iterable[int]
+) -> list[dict[str, float]]:
+    """Fetch performance metrics for the given listings."""
+    results: list[dict[str, float]] = []
+    for listing_id in listing_ids:
+        try:
+            resp = requests.get(f"{api_url}/listings/{listing_id}/metrics", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            results.append(
+                {
+                    "listing_id": float(listing_id),
+                    "views": float(data.get("views", 0)),
+                    "favorites": float(data.get("favorites", 0)),
+                    "orders": float(data.get("orders", 0)),
+                    "revenue": float(data.get("revenue", 0.0)),
+                }
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network
+            logger.warning("failed to fetch metrics for %s: %s", listing_id, exc)
+    return results
+
+
+def store_marketplace_metrics(metrics: Iterable[Mapping[str, float]]) -> None:
+    """Persist marketplace metrics to the database."""
+    rows = [
+        models.MarketplacePerformanceMetric(
+            listing_id=int(m["listing_id"]),
+            timestamp=datetime.now(timezone.utc),
+            views=int(m["views"]),
+            favorites=int(m["favorites"]),
+            orders=int(m["orders"]),
+            revenue=float(m["revenue"]),
+        )
+        for m in metrics
+    ]
+    if not rows:
+        return
+    with session_scope() as session:
+        session.add_all(rows)
+        logger.info("stored %s marketplace metrics", len(rows))
+
+
+def schedule_marketplace_ingestion(
+    scheduler: "BaseScheduler",
+    api_url: str,
+    listing_ids: Iterable[int],
+    interval_minutes: int = 60,
+) -> "Job":
+    """Register a scheduled job to fetch and store marketplace metrics."""
+
+    def _job() -> None:
+        metrics = fetch_marketplace_metrics(api_url, listing_ids)
+        store_marketplace_metrics(metrics)
+
+    return scheduler.add_job(
+        _job, "interval", minutes=interval_minutes, next_run_time=None
+    )

--- a/backend/feedback-loop/tests/test_ingestion.py
+++ b/backend/feedback-loop/tests/test_ingestion.py
@@ -1,0 +1,52 @@
+"""Tests for performance metrics ingestion."""
+
+from __future__ import annotations
+
+import os
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+from apscheduler.schedulers.background import BackgroundScheduler
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+@pytest.fixture()
+def _db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path}/ingest.db"
+    import backend.shared.db as db
+
+    importlib.reload(db)
+    from backend.shared.db import Base, models as db_models  # noqa: F401
+
+    Base.metadata.create_all(db.engine)
+    try:
+        yield db
+    finally:
+        Base.metadata.drop_all(db.engine)
+
+
+def test_schedule_marketplace_ingestion(_db, requests_mock):
+    """Job should store fetched metrics."""
+    from feedback_loop import ingestion
+
+    url = "http://api.example.com"
+    requests_mock.get(
+        f"{url}/listings/1/metrics",
+        json={"views": 5, "favorites": 2, "orders": 1, "revenue": 3.5},
+    )
+
+    scheduler = BackgroundScheduler()
+    job = ingestion.schedule_marketplace_ingestion(scheduler, url, [1], 1)
+    job.func()
+
+    with _db.session_scope() as session:
+        row = session.query(ingestion.models.MarketplacePerformanceMetric).first()
+        assert row is not None
+        assert row.views == 5
+        assert row.favorites == 2
+        assert row.orders == 1
+        assert row.revenue == 3.5

--- a/backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py
+++ b/backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py
@@ -1,0 +1,40 @@
+"""Add marketplace performance metrics table."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create marketplace_performance_metrics table."""
+    op.create_table(
+        "marketplace_performance_metrics",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("listing_id", sa.Integer, sa.ForeignKey("listings.id")),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("views", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("favorites", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("orders", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("revenue", sa.Float(), nullable=False, server_default="0"),
+    )
+    op.create_index(
+        op.f("ix_marketplace_performance_metrics_listing_id"),
+        "marketplace_performance_metrics",
+        ["listing_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop marketplace_performance_metrics table."""
+    op.drop_index(
+        op.f("ix_marketplace_performance_metrics_listing_id"),
+        table_name="marketplace_performance_metrics",
+    )
+    op.drop_table("marketplace_performance_metrics")

--- a/backend/shared/db/models.py
+++ b/backend/shared/db/models.py
@@ -126,6 +126,22 @@ class MarketplaceMetric(Base):
     listing: Mapped[Listing] = relationship()
 
 
+class MarketplacePerformanceMetric(Base):
+    """Detailed performance metrics for a listing."""
+
+    __tablename__ = "marketplace_performance_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    listing_id: Mapped[int] = mapped_column(ForeignKey("listings.id"))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    views: Mapped[int] = mapped_column(Integer, default=0)
+    favorites: Mapped[int] = mapped_column(Integer, default=0)
+    orders: Mapped[int] = mapped_column(Integer, default=0)
+    revenue: Mapped[float] = mapped_column(Float, default=0.0)
+
+    listing: Mapped[Listing] = relationship()
+
+
 class Embedding(Base):
     """Content embedding stored as a pgvector."""
 


### PR DESCRIPTION
## Summary
- fetch performance metrics from marketplace APIs
- save data in new `marketplace_performance_metrics` table
- expose scheduler option to ingest marketplace metrics
- test ingestion job with mocked API

## Testing
- `flake8 backend/feedback-loop/tests/test_ingestion.py backend/feedback-loop/feedback_loop/ingestion.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/feedback_loop/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py`
- `mypy --ignore-missing-imports backend/feedback-loop/tests/test_ingestion.py backend/feedback-loop/feedback_loop/ingestion.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/feedback_loop/__init__.py backend/shared/db/models.py backend/shared/db/migrations/scoring_engine/versions/0011_add_marketplace_performance_table.py`
- `pytest backend/feedback-loop/tests/test_ingestion.py -W error` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_6879526a8f9083318b511433e781b79c