### PR TITLE
Add Redis rate limit middleware

### DIFF
--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -3,16 +3,21 @@
 import logging
 import os
 import uuid
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, cast
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.gzip import GZipMiddleware
+from jose import JWTError, jwt
+from redis.asyncio import Redis
 
 from .routes import router
 from backend.shared.tracing import configure_tracing
 from backend.shared.profiling import add_profiling
 from backend.shared.logging import configure_logging
 from backend.shared import add_error_handlers, configure_sentry
+from .rate_limiter import UserRateLimiter
+from .settings import settings
+from .auth import ALGORITHM, SECRET_KEY
 
 
 configure_logging()
@@ -25,6 +30,27 @@ configure_tracing(app, SERVICE_NAME)
 configure_sentry(app, SERVICE_NAME)
 add_profiling(app)
 add_error_handlers(app)
+
+rate_limiter = UserRateLimiter(
+    Redis.from_url(settings.redis_url),
+    settings.rate_limit_per_user,
+    settings.rate_limit_window,
+)
+
+
+def _identify_user(request: Request) -> str:
+    """Return identifier for rate limiting, token subject or client IP."""
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            sub = cast(str | None, payload.get("sub"))
+            if sub is not None:
+                return sub
+        except JWTError:  # pragma: no cover - invalid tokens treated as anonymous
+            pass
+    return cast(str, request.client.host)
 
 
 @app.middleware("http")
@@ -45,6 +71,21 @@ async def add_correlation_id(
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response
+
+
+@app.middleware("http")
+async def enforce_rate_limit(
+    request: Request,
+    call_next: Callable[[Request], Coroutine[None, None, Response]],
+) -> Response:
+    """Reject requests that exceed the per-user limit."""
+    user_id = _identify_user(request)
+    if not await rate_limiter.acquire(user_id):
+        return Response(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content="Rate limit exceeded",
+        )
+    return await call_next(request)
 
 
 @app.get("/health")

--- a/backend/api-gateway/src/api_gateway/rate_limiter.py
+++ b/backend/api-gateway/src/api_gateway/rate_limiter.py
@@ -1,0 +1,41 @@
+"""Redis-backed token bucket rate limiter."""
+
+from __future__ import annotations
+
+import asyncio
+from redis.asyncio import Redis, WatchError
+
+
+class UserRateLimiter:
+    """Manage request quotas for individual users."""
+
+    def __init__(self, redis: Redis, limit: int, window: int) -> None:
+        """Instantiate the limiter with ``limit`` tokens per ``window`` seconds."""
+        self._redis = redis
+        self._limit = limit
+        self._window = window
+
+    async def acquire(self, user_id: str) -> bool:
+        """Consume a token for ``user_id`` if available."""
+        key = f"tokens:{user_id}"
+        async with self._redis.pipeline() as pipe:
+            while True:
+                try:
+                    await pipe.watch(key)
+                    raw = await pipe.get(key)
+                    if raw is None:
+                        pipe.multi()
+                        pipe.set(key, self._limit - 1, ex=self._window)
+                        await pipe.execute()
+                        return True
+                    tokens = int(raw)
+                    if tokens <= 0:
+                        await pipe.unwatch()
+                        await asyncio.sleep(0)
+                        return False
+                    pipe.multi()
+                    pipe.decr(key)
+                    await pipe.execute()
+                    return True
+                except WatchError:
+                    continue

--- a/backend/api-gateway/src/api_gateway/settings.py
+++ b/backend/api-gateway/src/api_gateway/settings.py
@@ -1,0 +1,21 @@
+"""Application settings for the API Gateway."""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from backend.shared.config import settings as shared_settings
+
+
+class Settings(BaseSettings):
+    """Configuration derived from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+    app_name: str = "api-gateway"
+    redis_url: str = shared_settings.redis_url
+    rate_limit_per_user: int = 60
+    rate_limit_window: int = 60
+
+
+settings = Settings()

--- a/backend/api-gateway/tests/test_rate_limit.py
+++ b/backend/api-gateway/tests/test_rate_limit.py
@@ -1,0 +1,29 @@
+"""Tests for request rate limiting middleware."""
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+sys.path.append(
+    str(Path(__file__).resolve().parents[2] / "mockup-generation")
+)  # noqa: E402
+
+import api_gateway.main as main_module  # noqa: E402
+
+
+def test_rate_limit_exceeded(monkeypatch: Any) -> None:
+    """Return 429 when requests exceed the per-user limit."""
+    monkeypatch.setenv("RATE_LIMIT_PER_USER", "1")
+    importlib.reload(main_module)
+    main_module.rate_limiter._redis = fakeredis.aioredis.FakeRedis()
+
+    client = TestClient(main_module.app)
+    resp1 = client.get("/status")
+    assert resp1.status_code == 200
+    resp2 = client.get("/status")
+    assert resp2.status_code == 429


### PR DESCRIPTION
## Summary
- add Redis token bucket middleware and settings
- apply middleware in the API Gateway
- add tests for returning 429 when limit exceeded

## Testing
- `flake8 backend/api-gateway/tests/test_rate_limit.py` *(and other new files)*
- `mypy backend/api-gateway/tests/test_rate_limit.py --follow-imports=skip --disable-error-code=misc`
- `python -m pytest -W error backend/api-gateway/tests/test_rate_limit.py` *(fails: Coverage not reached)*
- `./scripts/setup_codex.sh` *(fails: npm dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_b_687957ee000083319654e6b77f935bd0