### PR TITLE
Add TimescaleDB support for MetricsStore

### DIFF
--- a/backend/optimization/storage.py
+++ b/backend/optimization/storage.py
@@ -1,32 +1,53 @@
-"""SQLite-based storage for resource metrics."""
+"""Storage backend for resource metrics."""
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Iterator, List
 
+import psycopg2
+from urllib.parse import urlparse
+
 from .metrics import ResourceMetric
 
 
 class MetricsStore:
-    """Store and retrieve resource metrics."""
+    """Store and retrieve resource metrics in SQLite or TimescaleDB."""
 
-    def __init__(self, db_path: str = "metrics.db") -> None:
+    def __init__(self, db_url: str | None = None) -> None:
         """Initialize the store and ensure the table exists."""
-        self.db_path = db_path
-        with self._get_connection() as conn:
-            conn.execute(
-                (
-                    "CREATE TABLE IF NOT EXISTS metrics (timestamp TEXT, "
-                    "cpu REAL, memory REAL)"
+        self.db_url = db_url or os.environ.get(
+            "METRICS_DB_URL", f"sqlite:///{os.path.abspath('metrics.db')}"
+        )
+        parsed = urlparse(self.db_url)
+        self._use_sqlite = str(parsed.scheme).startswith("sqlite")
+        if self._use_sqlite:
+            self.db_path = parsed.path
+            with self._get_sqlite_conn() as conn:
+                conn.execute(
+                    (
+                        "CREATE TABLE IF NOT EXISTS metrics (timestamp TEXT, "
+                        "cpu REAL, memory REAL)"
+                    )
                 )
-            )
+        else:
+            with self._get_pg_conn() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        (
+                            "CREATE TABLE IF NOT EXISTS metrics (timestamp "
+                            "TIMESTAMPTZ, cpu DOUBLE PRECISION, memory DOUBLE "
+                            "PRECISION)"
+                        )
+                    )
+                    conn.commit()
 
     @contextmanager
-    def _get_connection(self) -> Iterator[sqlite3.Connection]:
-        """Context manager returning a SQLite connection."""
+    def _get_sqlite_conn(self) -> Iterator[sqlite3.Connection]:
+        """Yield a SQLite connection."""
         conn = sqlite3.connect(self.db_path)
         try:
             yield conn
@@ -34,23 +55,63 @@ class MetricsStore:
             conn.commit()
             conn.close()
 
+    @contextmanager
+    def _get_pg_conn(self) -> Iterator[psycopg2.extensions.connection]:
+        """Yield a PostgreSQL connection."""
+        conn = psycopg2.connect(self.db_url)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
     def add_metric(self, metric: ResourceMetric) -> None:
         """Add a metric entry to the database."""
-        with self._get_connection() as conn:
-            conn.execute(
-                "INSERT INTO metrics VALUES (?, ?, ?)",
-                (metric.timestamp.isoformat(), metric.cpu_percent, metric.memory_mb),
-            )
+        if self._use_sqlite:
+            with self._get_sqlite_conn() as conn:
+                conn.execute(
+                    "INSERT INTO metrics VALUES (?, ?, ?)",
+                    (
+                        metric.timestamp.isoformat(),
+                        metric.cpu_percent,
+                        metric.memory_mb,
+                    ),
+                )
+        else:
+            with self._get_pg_conn() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO metrics VALUES (%s, %s, %s)",
+                        (
+                            metric.timestamp.isoformat(),
+                            metric.cpu_percent,
+                            metric.memory_mb,
+                        ),
+                    )
+                    conn.commit()
 
     def get_metrics(self) -> List[ResourceMetric]:
         """Retrieve all stored metrics."""
-        with self._get_connection() as conn:
-            rows = conn.execute("SELECT timestamp, cpu, memory FROM metrics").fetchall()
-        return [
-            ResourceMetric(
-                timestamp=datetime.fromisoformat(ts),
-                cpu_percent=cpu,
-                memory_mb=memory,
+        if self._use_sqlite:
+            with self._get_sqlite_conn() as conn:
+                rows = conn.execute(
+                    "SELECT timestamp, cpu, memory FROM metrics"
+                ).fetchall()
+        else:
+            with self._get_pg_conn() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT timestamp, cpu, memory FROM metrics")
+                    rows = cur.fetchall()
+        result: List[ResourceMetric] = []
+        for ts, cpu, memory in rows:
+            if isinstance(ts, datetime):
+                timestamp = ts
+            else:
+                timestamp = datetime.fromisoformat(str(ts))
+            result.append(
+                ResourceMetric(
+                    timestamp=timestamp,
+                    cpu_percent=cpu,
+                    memory_mb=memory,
+                )
             )
-            for ts, cpu, memory in rows
-        ]
+        return result

--- a/tests/test_resource_metrics_store.py
+++ b/tests/test_resource_metrics_store.py
@@ -1,0 +1,42 @@
+"""Integration tests for the resource MetricsStore."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from backend.optimization.storage import MetricsStore
+from backend.optimization.metrics import ResourceMetric
+import psycopg2
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        None,  # default sqlite
+        "postgresql://postgres:postgres@localhost/test_metrics",
+    ],
+)
+def test_add_and_get_metrics(url: str | None, tmp_path: Path) -> None:
+    """Ensure metrics are persisted and fetched using different backends."""
+    if url is None:
+        db_path = tmp_path / "metrics.db"
+        store = MetricsStore(f"sqlite:///{db_path}")
+    else:
+        store = MetricsStore(url)
+        # ensure clean table for test isolation
+        with psycopg2.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute("TRUNCATE metrics")
+            conn.commit()
+
+    metric = ResourceMetric(
+        timestamp=datetime.now(timezone.utc), cpu_percent=1.0, memory_mb=2.0
+    )
+    store.add_metric(metric)
+    metrics = store.get_metrics()
+    assert len(metrics) == 1
+    assert metrics[0].cpu_percent == 1.0
+    assert metrics[0].memory_mb == 2.0


### PR DESCRIPTION
## Summary
- extend `MetricsStore` to select SQLite or PostgreSQL/TimescaleDB backend
- add integration test covering both backends

## Testing
- `mypy backend/optimization/storage.py tests/test_resource_metrics_store.py`
- `flake8 backend/optimization/storage.py tests/test_resource_metrics_store.py`
- `pytest tests/test_resource_metrics_store.py -W error` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_687957e7caf4833199e5d2e82c4f8741