### PR TITLE
Compute nightly weights from metrics

### DIFF
--- a/backend/feedback-loop/feedback_loop/scheduler.py
+++ b/backend/feedback-loop/feedback_loop/scheduler.py
@@ -30,16 +30,11 @@ def setup_scheduler(
         logger.info("processed metrics frame size %s", len(df))
 
     def nightly_update() -> None:
-        weights = {
-            "freshness": 1.0,
-            "engagement": 1.0,
-            "novelty": 1.0,
-            "community_fit": 1.0,
-            "seasonality": 1.0,
-        }
-        update_weights(scoring_api, weights)
+        df = ingest_metrics(metrics_source)
+        weights = update_weights(scoring_api, df.to_dict("records"))
         allocation = ab_manager.allocate_budget(total_budget=100.0)
         logger.info("budget allocation %s", allocation)
+        logger.info("updated weights payload %s", weights)
 
     scheduler.add_job(hourly_ingest, "interval", hours=1, next_run_time=None)
     scheduler.add_job(nightly_update, "cron", hour=0, minute=0, next_run_time=None)

--- a/backend/feedback-loop/feedback_loop/weight_updater.py
+++ b/backend/feedback-loop/feedback_loop/weight_updater.py
@@ -3,15 +3,48 @@
 from __future__ import annotations
 
 import logging
-from typing import Mapping
+from typing import Iterable, Mapping
+
+import pandas as pd
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 
-def update_weights(api_url: str, weights: Mapping[str, float]) -> None:
-    """Send weight updates to the scoring engine."""
+def update_weights(
+    api_url: str, metrics: Iterable[Mapping[str, float]]
+) -> Mapping[str, float]:
+    """Compute weights from metrics and update the scoring engine."""
+    df = pd.DataFrame(metrics)
+    ctr = 0.0
+    if {"clicks", "impressions"} <= set(df.columns):
+        impressions_sum = float(df["impressions"].sum())
+        ctr = float(df["clicks"].sum() / impressions_sum) if impressions_sum else 0.0
+    elif "ctr" in df.columns:
+        ctr = float(df["ctr"].mean())
+
+    conv_rate = 0.0
+    if {"purchases", "clicks"} <= set(df.columns):
+        clicks_sum = float(df["clicks"].sum())
+        conv_rate = float(df["purchases"].sum() / clicks_sum) if clicks_sum else 0.0
+    elif {"conversions", "impressions"} <= set(df.columns):
+        impressions_sum = float(df["impressions"].sum())
+        conv_rate = (
+            float(df["conversions"].sum() / impressions_sum) if impressions_sum else 0.0
+        )
+    elif "conversion_rate" in df.columns:
+        conv_rate = float(df["conversion_rate"].mean())
+
+    weights = {
+        "freshness": 1.0,
+        "engagement": ctr,
+        "novelty": 1.0,
+        "community_fit": conv_rate,
+        "seasonality": 1.0,
+    }
+
     response = requests.put(f"{api_url}/weights", json=weights, timeout=5)
     response.raise_for_status()
     logger.info("updated weights: %s", weights)
+    return weights

--- a/backend/feedback-loop/tests/test_weight_updater.py
+++ b/backend/feedback-loop/tests/test_weight_updater.py
@@ -1,17 +1,26 @@
 """Tests for weight updater."""
 
 from pathlib import Path
+from typing import Any
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT.parent))  # noqa: E402
+sys.path.append(str(ROOT / "feedback-loop"))  # noqa: E402
 
-from feedback_loop import update_weights
+from feedback_loop import update_weights  # noqa: E402
 
 
-def test_update_weights(requests_mock) -> None:
-    """Update endpoint should receive provided weights."""
+def test_update_weights(requests_mock: Any) -> None:
+    """Payload should contain aggregated CTR and conversion rate."""
     url = "http://example.com"
     requests_mock.put(f"{url}/weights", json={})
-    update_weights(url, {"freshness": 1.0})
+    metrics = [
+        {"clicks": 10, "impressions": 100, "purchases": 5},
+        {"clicks": 5, "impressions": 50, "purchases": 2},
+    ]
+    weights = update_weights(url, metrics)
     assert requests_mock.called
-    assert requests_mock.request_history[0].json() == {"freshness": 1.0}
+    assert requests_mock.request_history[0].json() == weights
+    assert weights["engagement"] == 0.1
+    assert round(weights["community_fit"], 2) == 0.35


### PR DESCRIPTION
## Summary
- compute updated weights from aggregated metrics
- schedule nightly weight updates
- test weight updater payloads

## Testing
- `flake8 backend/feedback-loop/feedback_loop/weight_updater.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/tests/test_weight_updater.py`
- `pydocstyle backend/feedback-loop/feedback_loop/weight_updater.py backend/feedback-loop/tests/test_weight_updater.py`
- `mypy backend/feedback-loop/feedback_loop/weight_updater.py backend/feedback-loop/feedback_loop/scheduler.py backend/feedback-loop/tests/test_weight_updater.py --follow-imports=skip --ignore-missing-imports`
- `pytest backend/feedback-loop/tests/test_weight_updater.py -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp')*

------
https://chatgpt.com/codex/tasks/task_b_687957dfc8348331aeb0cc26b661a9fd