### PR TITLE
Add recommendations endpoint

### DIFF
--- a/backend/optimization/api.py
+++ b/backend/optimization/api.py
@@ -80,6 +80,13 @@ def get_optimizations() -> List[str]:
     return analyzer.recommend_optimizations()
 
 
+@app.get("/recommendations")
+def get_recommendations() -> List[str]:
+    """Return top optimization actions."""
+    analyzer = MetricsAnalyzer(store.get_metrics())
+    return analyzer.top_recommendations()
+
+
 @app.get("/health")
 async def health() -> dict[str, str]:
     """Return service liveness."""

--- a/backend/optimization/metrics.py
+++ b/backend/optimization/metrics.py
@@ -60,3 +60,12 @@ class MetricsAnalyzer:
                 "Investigate memory leaks or reduce memory footprint"
             )
         return recommendations
+
+    def top_recommendations(self, limit: int = 3) -> List[str]:
+        """
+        Return the top optimization recommendations.
+
+        This simply limits the list returned by :meth:`recommend_optimizations`.
+        """
+
+        return self.recommend_optimizations()[:limit]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,6 +37,7 @@ Check that the API and frontend respond.
 
 ```bash
 curl http://localhost:8000/health
+curl http://localhost:8000/recommendations
 curl http://localhost:3000
 ```
 

--- a/openapi/optimization.json
+++ b/openapi/optimization.json
@@ -116,6 +116,29 @@
           }
         }
       }
+    },
+    "/recommendations": {
+      "get": {
+        "summary": "Get Recommendations",
+        "description": "Return top optimization actions.",
+        "operationId": "get_recommendations_recommendations_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Get Recommendations Recommendations Get"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,9 @@ def test_add_metric_and_get_optimizations() -> None:
     response = client.get("/optimizations")
     assert response.status_code == 200
     assert response.json() != []
+    response = client.get("/recommendations")
+    assert response.status_code == 200
+    assert response.json() != []
 
 
 def test_health_ready_endpoints() -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,3 +18,18 @@ def test_average_cpu_memory() -> None:
     analyzer = MetricsAnalyzer(metrics)
     assert analyzer.average_cpu() > 50
     assert analyzer.average_memory() == 512
+
+
+def test_top_recommendations() -> None:
+    """Ensure top recommendations are returned in priority order."""
+    metrics = [
+        ResourceMetric(
+            datetime.now(timezone.utc) - timedelta(minutes=1),
+            90,
+            2048,
+        )
+    ]
+    analyzer = MetricsAnalyzer(metrics)
+    recs = analyzer.top_recommendations()
+    assert recs != []
+    assert len(recs) <= 3


### PR DESCRIPTION
## Summary
- provide `top_recommendations` helper in `MetricsAnalyzer`
- expose `/recommendations` endpoint in optimization API
- document new endpoint in quickstart guide and OpenAPI spec
- test recommendations API and metrics helper

## Testing
- `flake8 backend/optimization/api.py backend/optimization/metrics.py tests/test_api.py tests/test_metrics.py`
- `mypy backend/optimization/api.py backend/optimization/metrics.py tests/test_api.py tests/test_metrics.py --ignore-missing-imports`
- `OTEL_SDK_DISABLED=true python -m pytest tests/test_api.py tests/test_metrics.py -W error --cov=. --cov-report=term --cov-report=xml --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_b_68795dff23888331b9bc47a3be611844