### PR TITLE
Configure Dagster webserver

### DIFF
--- a/backend/orchestrator/README.md
+++ b/backend/orchestrator/README.md
@@ -10,3 +10,15 @@ This module contains all Dagster jobs and schedules for desAInz.
 Metrics for job success and failure are exported as Prometheus counters:
 `backup_job_success_total`, `backup_job_failure_total`, `cleanup_job_success_total`, and `cleanup_job_failure_total`.
 
+
+## Dagster UI
+
+Start the Dagster webserver to inspect pipeline status and logs:
+
+```bash
+./scripts/run_dagster_webserver.sh
+```
+
+Then open http://localhost:3000 in your browser. The server loads
+`backend/orchestrator/workspace.yaml` and `backend/orchestrator/dagster.yaml`
+for configuration.

--- a/backend/orchestrator/dagster.yaml
+++ b/backend/orchestrator/dagster.yaml
@@ -1,0 +1,11 @@
+instance_class: dagster._core.instance.DagsterInstance
+local_artifact_storage:
+  module: dagster._core.storage.root
+  class: LocalArtifactStorage
+  config:
+    base_dir: "${DAGSTER_HOME}/artifacts"
+compute_logs:
+  module: dagster._core.storage.local_compute_log_manager
+  class: LocalComputeLogManager
+  config:
+    base_dir: "${DAGSTER_HOME}/logs"

--- a/backend/orchestrator/orchestrator/repository.py
+++ b/backend/orchestrator/orchestrator/repository.py
@@ -1,0 +1,12 @@
+"""Dagster definitions for the orchestrator."""
+
+from dagster import Definitions
+
+from .jobs import backup_job, cleanup_job, idea_job
+from .schedules import daily_backup_schedule, hourly_cleanup_schedule
+
+
+defs = Definitions(
+    jobs=[idea_job, backup_job, cleanup_job],
+    schedules=[daily_backup_schedule, hourly_cleanup_schedule],
+)

--- a/backend/orchestrator/workspace.yaml
+++ b/backend/orchestrator/workspace.yaml
@@ -1,0 +1,2 @@
+load_from:
+  - python_module: orchestrator.repository

--- a/scripts/run_dagster_webserver.sh
+++ b/scripts/run_dagster_webserver.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Start Dagster webserver for the orchestrator.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+export DAGSTER_HOME="${DAGSTER_HOME:-$ROOT_DIR/backend/orchestrator}"
+exec dagster-webserver -w backend/orchestrator/workspace.yaml -h 0.0.0.0 -p 3000


### PR DESCRIPTION
## Summary
- add Dagster definitions and workspace config
- configure Dagster instance logging
- provide helper script to launch Dagster webserver
- document how to access the Dagster UI

## Testing
- `flake8 backend/orchestrator/orchestrator/repository.py`
- `pydocstyle backend/orchestrator/orchestrator/repository.py`
- `mypy backend/orchestrator/orchestrator/repository.py --ignore-missing-imports` *(fails: MissingGreenlet, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose', and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6879628769d48331a8896b6d5fb629e8