### PR TITLE
Add Kubernetes manifests

### DIFF
--- a/infrastructure/k8s/base/api-gateway-deployment.yaml
+++ b/infrastructure/k8s/base/api-gateway-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: example/api-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/api-gateway-service.yaml
+++ b/infrastructure/k8s/base/api-gateway-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: api-gateway
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/infrastructure/k8s/base/api-gateway-servicemonitor.yaml
+++ b/infrastructure/k8s/base/api-gateway-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  selector:
+    matchLabels:
+      app: api-gateway
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/base/configmap.yaml
+++ b/infrastructure/k8s/base/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: placeholder-config
+  name: shared-config
 data:
   EXAMPLE_ENV: "value"

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -1,8 +1,20 @@
 resources:
-  - deployment.yaml
-  - service.yaml
+  - api-gateway-deployment.yaml
+  - api-gateway-service.yaml
+  - api-gateway-servicemonitor.yaml
+  - marketplace-publisher-deployment.yaml
+  - marketplace-publisher-service.yaml
+  - marketplace-publisher-servicemonitor.yaml
+  - signal-ingestion-deployment.yaml
+  - signal-ingestion-service.yaml
+  - signal-ingestion-servicemonitor.yaml
+  - scoring-engine-deployment.yaml
+  - scoring-engine-service.yaml
+  - scoring-engine-servicemonitor.yaml
+  - monitoring-deployment.yaml
+  - monitoring-service.yaml
+  - monitoring-servicemonitor.yaml
   - configmap.yaml
   - secret.yaml
-  - servicemonitor.yaml
   - loki-deployment.yaml
   - loki-service.yaml

--- a/infrastructure/k8s/base/marketplace-publisher-deployment.yaml
+++ b/infrastructure/k8s/base/marketplace-publisher-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-publisher
+  labels:
+    app: marketplace-publisher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: marketplace-publisher
+  template:
+    metadata:
+      labels:
+        app: marketplace-publisher
+    spec:
+      containers:
+        - name: marketplace-publisher
+          image: example/marketplace-publisher:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/marketplace-publisher-service.yaml
+++ b/infrastructure/k8s/base/marketplace-publisher-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: placeholder
+  name: marketplace-publisher
 spec:
   type: ClusterIP
   selector:
-    app: placeholder
+    app: marketplace-publisher
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8000

--- a/infrastructure/k8s/base/marketplace-publisher-servicemonitor.yaml
+++ b/infrastructure/k8s/base/marketplace-publisher-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: marketplace-publisher
+  labels:
+    app: marketplace-publisher
+spec:
+  selector:
+    matchLabels:
+      app: marketplace-publisher
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/base/monitoring-deployment.yaml
+++ b/infrastructure/k8s/base/monitoring-deployment.yaml
@@ -1,33 +1,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: placeholder
+  name: monitoring
   labels:
-    app: placeholder
+    app: monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: placeholder
+      app: monitoring
   template:
     metadata:
       labels:
-        app: placeholder
+        app: monitoring
     spec:
       containers:
-        - name: placeholder
-          image: example/placeholder:latest
+        - name: monitoring
+          image: example/monitoring:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 80
+            - containerPort: 8000
           env:
             - name: LOKI_URL
               value: http://loki:3100
           envFrom:
             - configMapRef:
-                name: placeholder-config
+                name: shared-config
             - secretRef:
-                name: placeholder-secret
+                name: shared-secret
           resources:
             limits:
               cpu: "500m"
@@ -37,7 +37,7 @@ spec:
               memory: "256Mi"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: 80
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/infrastructure/k8s/base/monitoring-service.yaml
+++ b/infrastructure/k8s/base/monitoring-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app: monitoring
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/infrastructure/k8s/base/monitoring-servicemonitor.yaml
+++ b/infrastructure/k8s/base/monitoring-servicemonitor.yaml
@@ -1,13 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: placeholder
+  name: monitoring
   labels:
-    app: placeholder
+    app: monitoring
 spec:
   selector:
     matchLabels:
-      app: placeholder
+      app: monitoring
   endpoints:
     - path: /metrics
       targetPort: 80

--- a/infrastructure/k8s/base/scoring-engine-deployment.yaml
+++ b/infrastructure/k8s/base/scoring-engine-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scoring-engine
+  labels:
+    app: scoring-engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scoring-engine
+  template:
+    metadata:
+      labels:
+        app: scoring-engine
+    spec:
+      containers:
+        - name: scoring-engine
+          image: example/scoring-engine:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5002
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/scoring-engine-service.yaml
+++ b/infrastructure/k8s/base/scoring-engine-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scoring-engine
+spec:
+  type: ClusterIP
+  selector:
+    app: scoring-engine
+  ports:
+    - port: 80
+      targetPort: 5002

--- a/infrastructure/k8s/base/scoring-engine-servicemonitor.yaml
+++ b/infrastructure/k8s/base/scoring-engine-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scoring-engine
+  labels:
+    app: scoring-engine
+spec:
+  selector:
+    matchLabels:
+      app: scoring-engine
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/base/secret.yaml
+++ b/infrastructure/k8s/base/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: placeholder-secret
+  name: shared-secret
 type: Opaque
 stringData:
   SECRET_KEY: "change-me"

--- a/infrastructure/k8s/base/signal-ingestion-deployment.yaml
+++ b/infrastructure/k8s/base/signal-ingestion-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signal-ingestion
+  labels:
+    app: signal-ingestion
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: signal-ingestion
+  template:
+    metadata:
+      labels:
+        app: signal-ingestion
+    spec:
+      containers:
+        - name: signal-ingestion
+          image: example/signal-ingestion:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          env:
+            - name: LOKI_URL
+              value: http://loki:3100
+          envFrom:
+            - configMapRef:
+                name: shared-config
+            - secretRef:
+                name: shared-secret
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20

--- a/infrastructure/k8s/base/signal-ingestion-service.yaml
+++ b/infrastructure/k8s/base/signal-ingestion-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signal-ingestion
+spec:
+  type: ClusterIP
+  selector:
+    app: signal-ingestion
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/infrastructure/k8s/base/signal-ingestion-servicemonitor.yaml
+++ b/infrastructure/k8s/base/signal-ingestion-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: signal-ingestion
+  labels:
+    app: signal-ingestion
+spec:
+  selector:
+    matchLabels:
+      app: signal-ingestion
+  endpoints:
+    - path: /metrics
+      targetPort: 80
+      interval: 30s

--- a/infrastructure/k8s/overlays/minikube/kustomization.yaml
+++ b/infrastructure/k8s/overlays/minikube/kustomization.yaml
@@ -3,10 +3,51 @@ resources:
 patches:
   - target:
       kind: Service
+      name: api-gateway
     patch: |-
       apiVersion: v1
       kind: Service
       metadata:
-        name: placeholder
+        name: api-gateway
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: marketplace-publisher
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: marketplace-publisher
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: signal-ingestion
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: signal-ingestion
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: scoring-engine
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: scoring-engine
+      spec:
+        type: NodePort
+  - target:
+      kind: Service
+      name: monitoring
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: monitoring
       spec:
         type: NodePort

--- a/infrastructure/k8s/overlays/production/hpa.yaml
+++ b/infrastructure/k8s/overlays/production/hpa.yaml
@@ -1,0 +1,94 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: marketplace-publisher
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: marketplace-publisher
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: signal-ingestion
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: signal-ingestion
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: scoring-engine
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: scoring-engine
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: monitoring
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: monitoring
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/overlays/production/kustomization.yaml
+++ b/infrastructure/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+patches:
+  - path: resources.yaml
+  - path: hpa.yaml

--- a/infrastructure/k8s/overlays/production/resources.yaml
+++ b/infrastructure/k8s/overlays/production/resources.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: api-gateway
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-publisher
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: marketplace-publisher
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signal-ingestion
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: signal-ingestion
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scoring-engine
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: scoring-engine
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: monitoring
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"


### PR DESCRIPTION
## Summary
- add real microservice manifests under `k8s/base`
- update minikube overlay with NodePort patches
- add production overlay with resource requests and HPAs

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install --legacy-peer-deps`
- `make setup` *(fails: ImportError in alembic env.py)*
- `make test` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_687971b74f1c83318889dc73e59cd1ef