### PR TITLE
Implement secret management via Docker/K8s secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ identify missing indexes.
 
 Local development uses dotenv files. Copy the `.env.example` in each service to `.env` and adjust the values for your environment. The services automatically load these variables using Pydantic `BaseSettings`.
 
-In production, secrets are stored in HashiCorp Vault or AWS Secrets Manager and injected into the running services by the deployment manifests. Do not rely on `.env` files in production.
+In production, secrets are stored in HashiCorp Vault or AWS Secrets Manager and surfaced to the containers via Docker secrets or Kubernetes Secrets. The settings modules read from `/run/secrets` if present. Do not rely on `.env` files in production.
 
 See [docs/security.md](docs/security.md) for the rotation procedure.
 

--- a/backend/analytics/auth.py
+++ b/backend/analytics/auth.py
@@ -12,8 +12,9 @@ from sqlalchemy import select
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import UserRole
+from backend.shared.config import settings as shared_settings
 
-SECRET_KEY = "change_this"  # In production use env var
+SECRET_KEY = shared_settings.secret_key or "change_this"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/backend/api-gateway/src/api_gateway/auth.py
+++ b/backend/api-gateway/src/api_gateway/auth.py
@@ -11,9 +11,10 @@ from typing import cast, Callable
 
 from backend.shared.db import session_scope
 from backend.shared.db.models import UserRole
+from backend.shared.config import settings as shared_settings
 
 
-SECRET_KEY = "change_this"  # In production use env var
+SECRET_KEY = shared_settings.secret_key or "change_this"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/backend/api-gateway/src/api_gateway/settings.py
+++ b/backend/api-gateway/src/api_gateway/settings.py
@@ -10,7 +10,7 @@ from backend.shared.config import settings as shared_settings
 class Settings(BaseSettings):
     """Configuration derived from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "api-gateway"
     redis_url: str = shared_settings.redis_url

--- a/backend/marketplace-publisher/src/marketplace_publisher/settings.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/settings.py
@@ -10,7 +10,7 @@ from backend.shared.config import settings as shared_settings
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "marketplace-publisher"
     log_level: str = "INFO"

--- a/backend/mockup-generation/mockup_generation/settings.py
+++ b/backend/mockup-generation/mockup_generation/settings.py
@@ -8,7 +8,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Expose API keys and provider selection."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_prefix="")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_prefix="", secrets_dir="/run/secrets"
+    )
 
     stability_ai_api_key: str | None = None
     openai_api_key: str | None = None

--- a/backend/monitoring/src/monitoring/settings.py
+++ b/backend/monitoring/src/monitoring/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Configuration loaded from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "monitoring"
     log_file: str = "app.log"

--- a/backend/service-template/src/settings.py
+++ b/backend/service-template/src/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "service-template"
     log_level: str = "INFO"

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -8,7 +8,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Centralized configuration for backend services."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_prefix="")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_prefix="", secrets_dir="/run/secrets"
+    )
 
     database_url: str = "sqlite:///shared.db"
     kafka_bootstrap_servers: str = "localhost:9092"
@@ -17,6 +19,7 @@ class Settings(BaseSettings):
     s3_access_key: str | None = None
     s3_secret_key: str | None = None
     s3_bucket: str | None = None
+    secret_key: str | None = None
 
 
 settings = Settings()

--- a/backend/signal-ingestion/src/signal_ingestion/settings.py
+++ b/backend/signal-ingestion/src/signal_ingestion/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Store configuration derived from environment variables."""
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir="/run/secrets")
 
     app_name: str = "signal-ingestion"
     log_level: str = "INFO"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,10 @@ services:
         reservations:
           devices:
             - capabilities: [gpu]
+    secrets:
+      - openai_api_key
+      - stability_ai_api_key
+      - huggingface_token
 
   # Optional monitoring stack
   monitoring:
@@ -155,3 +159,12 @@ volumes:
   zookeeper-data:
   kafka-data:
   minio-data:
+secrets:
+  secret_key:
+    file: ./secrets/secret_key.txt
+  openai_api_key:
+    file: ./secrets/openai_api_key.txt
+  stability_ai_api_key:
+    file: ./secrets/stability_ai_api_key.txt
+  huggingface_token:
+    file: ./secrets/huggingface_token.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,8 @@ The `scripts` directory provides helper scripts for setting up storage and CDN r
 
 The `backend/service-template` directory contains a minimal FastAPI service. The
 application loads configuration from environment variables using
-`pydantic.BaseSettings`. Variables can be provided via a `.env` file. The
+`pydantic.BaseSettings`. Variables can be provided via a `.env` file for local
+development or via Docker/Kubernetes secrets mounted under `/run/secrets`. The
 `Settings` class is defined in `src/settings.py` and read on startup.
 
 ## Load Testing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,9 @@ This project uses environment variables for all runtime configuration. The
 example files `.env.dev.example`, `.env.staging.example` and
 `.env.prod.example` provide sample values for each deployment stage. Copy the
 appropriate file to `.env` and adjust the values before running services
-locally or in CI.
+locally or in CI. In production, sensitive variables are mounted from Docker or
+Kubernetes secrets under `/run/secrets` and loaded automatically by the
+application settings classes.
 
 | Variable | Description |
 | --- | --- |

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,11 +7,14 @@ This project relies on environment variables for configuration.
 - Copy `.env.example` files to `.env` inside each service directory.
 - Adjust the values for your local setup.
 - The applications load these variables automatically via `pydantic.BaseSettings`.
+- For a production-like setup with Docker Compose, place sensitive values in
+  files under `secrets/` and reference them as Docker secrets.
 
 ## Production
 
-- Secrets are stored in HashiCorp Vault or AWS Secrets Manager.
-- Deployment manifests fetch the secrets at runtime.
+- Secrets are stored in HashiCorp Vault or AWS Secrets Manager and exposed to
+  the containers using Kubernetes Secrets.
+- Deployment manifests mount the secrets under `/run/secrets`.
 - `.env` files are **not** used in production.
 
 ## Secret rotation procedure

--- a/infrastructure/k8s/base/secret.yaml
+++ b/infrastructure/k8s/base/secret.yaml
@@ -5,3 +5,6 @@ metadata:
 type: Opaque
 stringData:
   SECRET_KEY: "change-me"
+  OPENAI_API_KEY: ""
+  STABILITY_AI_API_KEY: ""
+  HUGGINGFACE_TOKEN: ""

--- a/secrets/.gitignore
+++ b/secrets/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,2 @@
+Store sensitive values in files within this directory for use with Docker Compose.
+For example, place your OpenAI API key in `openai_api_key.txt` and reference it as a Docker secret.


### PR DESCRIPTION
## Summary
- mount secrets under `/run/secrets`
- load secrets via Pydantic `secrets_dir`
- document Docker/K8s secret usage

## Testing
- `black backend/shared/config.py backend/monitoring/src/monitoring/settings.py backend/mockup-generation/mockup_generation/settings.py backend/service-template/src/settings.py backend/api-gateway/src/api_gateway/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py`
- `flake8 backend/shared/config.py backend/monitoring/src/monitoring/settings.py backend/mockup-generation/mockup_generation/settings.py backend/service-template/src/settings.py backend/api-gateway/src/api_gateway/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py`
- `mypy backend/shared/config.py backend/monitoring/src/monitoring/settings.py backend/mockup-generation/mockup_generation/settings.py backend/service-template/src/settings.py backend/api-gateway/src/api_gateway/settings.py backend/marketplace-publisher/src/marketplace_publisher/settings.py backend/signal-ingestion/src/signal_ingestion/settings.py backend/api-gateway/src/api_gateway/auth.py backend/analytics/auth.py` *(fails: 13 errors)*
- `python -m pytest -W error` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68797960ae008331a11426f062b959cb