### PR TITLE
Add CI/CD workflow with Helm deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,77 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          npm ci
+          python -m pip install -e .
+      - name: Run linting
+        run: make lint
+      - name: Run tests
+        run: make test
+
+  docker:
+    needs: build-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build images
+        run: make docker-build
+      - name: Push images
+        env:
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          TAG: ${{ github.sha }}
+        run: make docker-push REGISTRY=$REGISTRY TAG=$TAG
+
+  deploy:
+    needs: docker
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.0'
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.3'
+      - name: Deploy to cluster
+        env:
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          TAG: ${{ github.sha }}
+          ENV: prod
+        run: make helm-deploy REGISTRY=$REGISTRY TAG=$TAG ENV=$ENV

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Makefile with common commands
 
+REGISTRY ?= ghcr.io/example
+TAG ?= latest
+ENV ?= dev
+
 up:
 	docker compose up -d
 
@@ -7,11 +11,22 @@ test:
 	python -m pytest -W error
 
 lint:
-	python -m flake8
-	npm run lint
+        python -m flake8
+        npm run lint
 
 setup:
-	alembic -c backend/shared/db/alembic_api_gateway.ini upgrade head
-	alembic -c backend/shared/db/alembic_scoring_engine.ini upgrade head
-	alembic -c backend/shared/db/alembic_marketplace_publisher.ini upgrade head
-	alembic -c backend/shared/db/alembic_signal_ingestion.ini upgrade head
+        alembic -c backend/shared/db/alembic_api_gateway.ini upgrade head
+        alembic -c backend/shared/db/alembic_scoring_engine.ini upgrade head
+        alembic -c backend/shared/db/alembic_marketplace_publisher.ini upgrade head
+        alembic -c backend/shared/db/alembic_signal_ingestion.ini upgrade head
+
+docker-build:
+        ./scripts/build-images.sh
+
+docker-push:
+        ./scripts/push-images.sh $(REGISTRY) $(TAG)
+
+helm-deploy:
+        ./scripts/helm_deploy.sh $(REGISTRY) $(TAG) $(ENV)
+
+ci: lint test docker-build

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Deploy all microservices via Helm.
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <registry> <tag> <env>" >&2
+  exit 1
+fi
+
+REGISTRY="$1"
+TAG="$2"
+ENV="$3"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHART_DIR="$ROOT_DIR/infrastructure/helm/all-services"
+
+helm dependency update "$CHART_DIR"
+helm upgrade --install desainz "$CHART_DIR" \
+  --set global.image.registry="$REGISTRY" \
+  --set global.image.tag="$TAG" \
+  -f "$CHART_DIR/values-$ENV.yaml"


### PR DESCRIPTION
## Summary
- add Makefile variables and targets for Docker build/push and Helm deploy
- create script to deploy Helm chart
- add CI/CD workflow to build images, run tests, push to registry and deploy to Kubernetes via Helm

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `npm ci --legacy-peer-deps`
- `pytest -W error -k '' -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_b_6879815305f48331bf93c65a7ba31567