### PR TITLE
Add orchestrator workflow test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,10 +34,15 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
           npm ci
           python -m pip install -e .
+      - name: Start services
+        run: docker compose -f docker-compose.test.yml up -d
       - name: Run tests
         run: |
           pytest -vv
           npm test
+      - name: Stop services
+        if: always()
+        run: docker compose -f docker-compose.test.yml down
 
   publish:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,0 +1,64 @@
+"""Integration test for end-to-end workflow via orchestrator."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend" / "orchestrator"))
+
+import types
+
+otel_mod = types.ModuleType("opentelemetry.exporter.otlp.proto.http.trace_exporter")
+otel_mod.OTLPSpanExporter = object  # type: ignore[attr-defined]
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    otel_mod,
+)
+os.makedirs("/run/secrets", exist_ok=True)
+
+from orchestrator import idea_job
+from orchestrator import ops
+
+
+class DummyResponse:
+    """Simple stand-in for :class:`requests.Response`."""
+
+    def __init__(self, data: dict[str, object]) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> dict[str, object]:
+        """Return payload."""
+        return self._data
+
+    def raise_for_status(self) -> None:  # pragma: no cover
+        """Do nothing as errors are not simulated."""
+        return None
+
+
+def _mock_post(url: str, *args: object, **kwargs: object) -> DummyResponse:
+    if url.endswith("/ingest"):
+        return DummyResponse({"signals": ["s1"]})
+    if url.endswith("/score"):
+        return DummyResponse({"score": 0.5})
+    if url.endswith("/generate"):
+        return DummyResponse({"items": ["mockup.png"]})
+    if url.endswith("/publish"):
+        return DummyResponse({"task_id": 1})
+    raise ValueError(f"unexpected url {url}")
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_full_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute the orchestrator job through all stages."""
+    monkeypatch.setattr(ops, "requests", SimpleNamespace(post=_mock_post))
+    os.environ["APPROVE_PUBLISHING"] = "true"
+    result = idea_job.execute_in_process()
+    assert result.success


### PR DESCRIPTION
## Summary
- add integration test covering orchestrator workflow
- spin up docker-compose services in CI to support integration tests

## Testing
- `black tests/integration/test_full_pipeline.py`
- `flake8 tests/integration/test_full_pipeline.py`
- `mypy tests/integration/test_full_pipeline.py`
- `pytest tests/integration/test_full_pipeline.py -vv` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_b_687984e275c88331ab66778fc5070058