### PR TITLE
Add PostgreSQL backup script

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -9,12 +9,8 @@ Backups run nightly using a Kubernetes CronJob defined in the `backup-jobs`
 Helm chart. The job executes `scripts/backup.py` inside a small container
 with `pg_dump` and the AWS CLI installed.
 
-The script performs two tasks:
-
-1. Dumps the PostgreSQL database to a temporary file and uploads it to the
-   S3 bucket specified by `BACKUP_BUCKET`.
-2. Synchronizes the MinIO data directory to the same bucket using
-   `aws s3 sync`.
+The script dumps the PostgreSQL database to a temporary file and uploads it to
+the S3 bucket specified by `BACKUP_BUCKET`.
 
 ## Restoring from Backup
 
@@ -26,8 +22,13 @@ The script performs two tasks:
    ```bash
    psql -h <db-host> -U <user> -d <db-name> -f restore.sql
    ```
-3. Retrieve the MinIO archive:
-   ```bash
-   aws s3 sync s3://<bucket>/minio/ /path/to/minio/data
-   ```
-4. Restart the MinIO service so it picks up the restored objects.
+
+## Verify Backup Integrity
+
+After restoring, run a simple query to ensure expected data is present:
+
+```bash
+psql -h <db-host> -U <user> -d <db-name> -c "SELECT count(*) FROM information_schema.tables;"
+```
+
+If the command returns a non-zero count, the backup was successfully restored.

--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -1,4 +1,4 @@
-"""Backup Postgres and MinIO data to S3."""
+"""Backup the PostgreSQL database to S3."""
 
 import os
 import subprocess
@@ -33,33 +33,12 @@ def dump_postgres(backup_dir: Path, bucket: str) -> None:
     dump_file.unlink()
 
 
-def backup_minio(data_path: Path, bucket: str) -> None:
-    """
-    Sync MinIO data directory to S3.
-
-    Args:
-        data_path: Local path to MinIO data.
-        bucket: Name of the S3 bucket.
-    """
-    run(
-        [
-            "aws",
-            "s3",
-            "sync",
-            str(data_path),
-            f"s3://{bucket}/minio/",
-        ]
-    )
-
-
 def main() -> None:
-    """Run database and object storage backups."""
+    """Run database backups."""
     bucket = os.environ["BACKUP_BUCKET"]
     backup_dir = Path(os.getenv("BACKUP_DIR", "/tmp"))
     backup_dir.mkdir(parents=True, exist_ok=True)
     dump_postgres(backup_dir, bucket)
-    data_path = Path(os.getenv("MINIO_DATA_PATH", "/data"))
-    backup_minio(data_path, bucket)
 
 
 if __name__ == "__main__":

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,49 @@
+"""Tests for the PostgreSQL backup script."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+from datetime import datetime
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+import scripts.backup as backup  # noqa: E402
+
+
+def test_dump_postgres_creates_and_uploads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Database dump should be uploaded and local file removed."""
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool = True) -> None:
+        commands.append(cmd)
+        if cmd[0] == "pg_dump":
+            # create dump file to mimic pg_dump output
+            dump_index = cmd.index("-f") + 1
+            Path(cmd[dump_index]).write_text("dump")
+
+    monkeypatch.setattr(backup, "run", fake_run)
+
+    class FakeDT(datetime):
+        @classmethod
+        def utcnow(cls) -> "FakeDT":
+            return cls(2025, 1, 1, 0, 0, 0)
+
+    monkeypatch.setattr(backup, "datetime", FakeDT)
+
+    backup.dump_postgres(tmp_path, "bucket")
+
+    expected_file = tmp_path / "postgres_20250101000000.sql"
+    assert ["pg_dump", "app", "-f", str(expected_file)] in commands
+    assert [
+        "aws",
+        "s3",
+        "cp",
+        str(expected_file),
+        f"s3://bucket/postgres/{expected_file.name}",
+    ] in commands
+    assert not expected_file.exists()


### PR DESCRIPTION
## Summary
- remove MinIO sync from `scripts/backup.py`
- update docs with restore instructions and integrity check
- add tests ensuring database dump is uploaded to S3

## Testing
- `flake8 scripts/backup.py tests/test_backup.py`
- `black --check scripts/backup.py tests/test_backup.py`
- `mypy scripts/backup.py tests/test_backup.py`
- `pytest tests/test_backup.py -q --cov=scripts.backup --cov-report=term --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_b_68798cb3cee08331a5c7e9fc71d80810