### PR TITLE
Add structured logging fields

### DIFF
--- a/backend/analytics/api.py
+++ b/backend/analytics/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from typing import Any, Callable, Coroutine, Dict, Iterable
+from typing import Any, Callable, Coroutine, Dict, Iterable, cast
 
 from fastapi import Depends, FastAPI, Request, Response
 from fastapi.responses import StreamingResponse
@@ -32,6 +32,11 @@ add_profiling(app)
 add_error_handlers(app)
 
 
+def _identify_user(request: Request) -> str:
+    """Return identifier for logging, header ``X-User`` or client IP."""
+    return cast(str, request.headers.get("X-User", request.client.host))
+
+
 @app.middleware("http")
 async def add_correlation_id(
     request: Request,
@@ -46,7 +51,15 @@ async def add_correlation_id(
         sentry_sdk.set_tag("correlation_id", correlation_id)
     except Exception:  # pragma: no cover - sentry optional
         pass
-    logger.info("request received", extra={"correlation_id": correlation_id})
+    logger.info(
+        "request received",
+        extra={
+            "correlation_id": correlation_id,
+            "user": _identify_user(request),
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response

--- a/backend/api-gateway/src/api_gateway/main.py
+++ b/backend/api-gateway/src/api_gateway/main.py
@@ -67,7 +67,15 @@ async def add_correlation_id(
         sentry_sdk.set_tag("correlation_id", correlation_id)
     except Exception:  # pragma: no cover - sentry optional
         pass
-    logger.info("request received", extra={"correlation_id": correlation_id})
+    logger.info(
+        "request received",
+        extra={
+            "correlation_id": correlation_id,
+            "user": _identify_user(request),
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response

--- a/backend/marketplace-publisher/src/marketplace_publisher/logging_config.py
+++ b/backend/marketplace-publisher/src/marketplace_publisher/logging_config.py
@@ -1,51 +1,5 @@
-"""Logging configuration for the service template."""
+"""Logging configuration using shared settings."""
 
-from __future__ import annotations
+from backend.shared.logging import configure_logging
 
-import json
-import logging
-from logging.config import dictConfig
-from typing import Any, Dict
-
-
-class CorrelationIdFilter(logging.Filter):
-    """Attach correlation IDs to log records."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Add the ``correlation_id`` attribute if missing."""
-        record.correlation_id = getattr(record, "correlation_id", "-")
-        return True
-
-
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON objects."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Return the JSON representation of ``record``."""
-        log_record: Dict[str, Any] = {
-            "time": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S%z"),
-            "level": record.levelname,
-            "name": record.name,
-            "message": record.getMessage(),
-            "correlation_id": getattr(record, "correlation_id", None),
-        }
-        return json.dumps(log_record)
-
-
-def configure_logging() -> None:
-    """Configure JSON logging with correlation IDs."""
-    log_config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "filters": {"correlation": {"()": CorrelationIdFilter}},
-        "formatters": {"json": {"()": JsonFormatter}},
-        "handlers": {
-            "default": {
-                "class": "logging.StreamHandler",
-                "formatter": "json",
-                "filters": ["correlation"],
-            }
-        },
-        "root": {"handlers": ["default"], "level": "INFO"},
-    }
-    dictConfig(log_config)
+__all__ = ["configure_logging"]

--- a/backend/monitoring/src/monitoring/logging_config.py
+++ b/backend/monitoring/src/monitoring/logging_config.py
@@ -1,36 +1,5 @@
-"""Logging configuration for the monitoring service."""
+"""Logging configuration using shared settings."""
 
-from __future__ import annotations
+from backend.shared.logging import configure_logging
 
-import json
-import logging
-from logging.config import dictConfig
-from typing import Any, Dict
-
-
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Return the JSON representation of ``record``."""
-        log_record: Dict[str, Any] = {
-            "time": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S%z"),
-            "level": record.levelname,
-            "name": record.name,
-            "message": record.getMessage(),
-        }
-        return json.dumps(log_record)
-
-
-def configure_logging() -> None:
-    """Configure application logging."""
-    config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {"json": {"()": JsonFormatter}},
-        "handlers": {
-            "default": {"class": "logging.StreamHandler", "formatter": "json"}
-        },
-        "root": {"handlers": ["default"], "level": "INFO"},
-    }
-    dictConfig(config)
+__all__ = ["configure_logging"]

--- a/backend/service-template/src/logging_config.py
+++ b/backend/service-template/src/logging_config.py
@@ -1,51 +1,5 @@
-"""Logging configuration for the service template."""
+"""Logging configuration using shared settings."""
 
-from __future__ import annotations
+from backend.shared.logging import configure_logging
 
-import json
-import logging
-from logging.config import dictConfig
-from typing import Any, Dict
-
-
-class CorrelationIdFilter(logging.Filter):
-    """Attach correlation IDs to log records."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Add the ``correlation_id`` attribute if missing."""
-        record.correlation_id = getattr(record, "correlation_id", "-")
-        return True
-
-
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON objects."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Return the JSON representation of ``record``."""
-        log_record: Dict[str, Any] = {
-            "time": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S%z"),
-            "level": record.levelname,
-            "name": record.name,
-            "message": record.getMessage(),
-            "correlation_id": getattr(record, "correlation_id", None),
-        }
-        return json.dumps(log_record)
-
-
-def configure_logging() -> None:
-    """Configure JSON logging with correlation IDs."""
-    log_config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "filters": {"correlation": {"()": CorrelationIdFilter}},
-        "formatters": {"json": {"()": JsonFormatter}},
-        "handlers": {
-            "default": {
-                "class": "logging.StreamHandler",
-                "formatter": "json",
-                "filters": ["correlation"],
-            }
-        },
-        "root": {"handlers": ["default"], "level": "INFO"},
-    }
-    dictConfig(log_config)
+__all__ = ["configure_logging"]

--- a/backend/service-template/src/main.py
+++ b/backend/service-template/src/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, cast
 
 from fastapi import FastAPI, Request, Response
 
@@ -24,6 +24,11 @@ add_profiling(app)
 add_error_handlers(app)
 
 
+def _identify_user(request: Request) -> str:
+    """Return identifier for logging, header ``X-User`` or client IP."""
+    return cast(str, request.headers.get("X-User", request.client.host))
+
+
 @app.middleware("http")
 async def add_correlation_id(
     request: Request,
@@ -39,7 +44,15 @@ async def add_correlation_id(
     except Exception:  # pragma: no cover - sentry optional
         pass
 
-    logger.info("request received", extra={"correlation_id": correlation_id})
+    logger.info(
+        "request received",
+        extra={
+            "correlation_id": correlation_id,
+            "user": _identify_user(request),
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
     response = await call_next(request)
     response.headers["X-Correlation-ID"] = correlation_id
     return response

--- a/backend/signal-ingestion/src/signal_ingestion/logging_config.py
+++ b/backend/signal-ingestion/src/signal_ingestion/logging_config.py
@@ -1,51 +1,5 @@
-"""Logging configuration for the signal ingestion service."""
+"""Logging configuration using shared settings."""
 
-from __future__ import annotations
+from backend.shared.logging import configure_logging
 
-import json
-import logging
-from logging.config import dictConfig
-from typing import Any, Dict
-
-
-class CorrelationIdFilter(logging.Filter):
-    """Attach correlation IDs to log records."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Add the ``correlation_id`` attribute if missing."""
-        record.correlation_id = getattr(record, "correlation_id", "-")
-        return True
-
-
-class JsonFormatter(logging.Formatter):
-    """Format log records as JSON objects."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Return the JSON representation of ``record``."""
-        log_record: Dict[str, Any] = {
-            "time": self.formatTime(record, datefmt="%Y-%m-%dT%H:%M:%S%z"),
-            "level": record.levelname,
-            "name": record.name,
-            "message": record.getMessage(),
-            "correlation_id": getattr(record, "correlation_id", None),
-        }
-        return json.dumps(log_record)
-
-
-def configure_logging() -> None:
-    """Configure JSON logging with correlation IDs."""
-    log_config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "filters": {"correlation": {"()": CorrelationIdFilter}},
-        "formatters": {"json": {"()": JsonFormatter}},
-        "handlers": {
-            "default": {
-                "class": "logging.StreamHandler",
-                "formatter": "json",
-                "filters": ["correlation"],
-            }
-        },
-        "root": {"handlers": ["default"], "level": "INFO"},
-    }
-    dictConfig(log_config)
+__all__ = ["configure_logging"]

--- a/docs/error_triage.md
+++ b/docs/error_triage.md
@@ -1,6 +1,6 @@
 # Error Monitoring and Triage
 
-Unhandled exceptions from backend services are sent to Sentry when `SENTRY_DSN` is configured. Each request middleware attaches a `correlation_id` which Sentry stores as a tag for easy filtering.
+Unhandled exceptions from backend services are sent to Sentry when `SENTRY_DSN` is configured. Each request middleware attaches a `correlation_id` which Sentry stores as a tag for easy filtering. Logs also include structured `user`, `path`, and `method` fields for every request.
 
 1. Sign in to the Sentry dashboard.
 2. Select the environment matching your deployment.


### PR DESCRIPTION
## Summary
- expand shared logging with request context
- simplify service logging configs to reuse shared module
- capture user and request info in service middleware
- document structured log fields

## Testing
- `black backend docs`
- `flake8 backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/logging_config.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/monitoring/src/monitoring/logging_config.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/logging_config.py backend/service-template/src/main.py backend/shared/logging.py backend/signal-ingestion/src/signal_ingestion/logging_config.py backend/signal-ingestion/src/signal_ingestion/main.py`
- `mypy backend/analytics/api.py backend/api-gateway/src/api_gateway/main.py backend/marketplace-publisher/src/marketplace_publisher/logging_config.py backend/marketplace-publisher/src/marketplace_publisher/main.py backend/monitoring/src/monitoring/logging_config.py backend/optimization/api.py backend/scoring-engine/scoring_engine/app.py backend/service-template/src/logging_config.py backend/service-template/src/main.py backend/shared/logging.py backend/signal-ingestion/src/signal_ingestion/logging_config.py backend/signal-ingestion/src/signal_ingestion/main.py` *(failed: Library stubs not installed)*
- `npm run lint` *(failed: Cannot find module '@eslint/eslintrc')*
- `npx stylelint "**/*.css"` *(failed: package missing)*
- `python -m pytest -W error` *(failed: 51 errors during collection)*
- `sphinx-build -W -b html docs docs/_build/html` *(failed: Could not import extension myst_parser)*

------
https://chatgpt.com/codex/tasks/task_b_6879a359a45483319c6a4c9b426d1551