### PR TITLE
Improve exception handling for publishing and generation

### DIFF
--- a/backend/mockup-generation/mockup_generation/generator.py
+++ b/backend/mockup-generation/mockup_generation/generator.py
@@ -62,7 +62,7 @@ class MockupGenerator:
             image = self.pipeline(
                 prompt=prompt, num_inference_steps=num_inference_steps
             ).images[0]
-        except Exception as exc:  # pylint: disable=broad-except
+        except (RuntimeError, ValueError, OSError) as exc:
             logger.warning("Local generation failed: %s. Falling back to API", exc)
             image = self._fallback_api(prompt)
         duration = perf_counter() - start
@@ -113,7 +113,7 @@ class MockupGenerator:
                     response.raise_for_status()
                     data = base64.b64decode(response.json()["artifacts"][0]["base64"])
                 return Image.open(BytesIO(data))
-            except Exception as exc:  # noqa: BLE001
+            except (requests.RequestException, OSError, ValueError) as exc:
                 logger.warning("Fallback provider error: %s", exc)
                 if attempt == 2:
                     raise


### PR DESCRIPTION
## Summary
- improve logging and exception handling for publishing
- target specific runtime and request errors for mockup generation

## Testing
- `python -m flake8 backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/mockup-generation/mockup_generation/generator.py`
- `python -m black backend/marketplace-publisher/src/marketplace_publisher/publisher.py backend/mockup-generation/mockup_generation/generator.py`
- `python -m mypy backend/mockup-generation/mockup_generation/generator.py`
- `python -m pytest -W error` *(fails: 52 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6879a64aa5888331a0634a66ae36d0c3