### PR TITLE
Add missing module docstrings

### DIFF
--- a/backend/analytics/__init__.py
+++ b/backend/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities and FastAPI routes for the analytics service."""

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
-from setuptools import setup, find_packages
+"""Package and distribute the desAInz application."""
+
+from setuptools import find_packages, setup
 
 setup(name="desAInz", version="0.1", packages=find_packages())


### PR DESCRIPTION
## Summary
- describe analytics backend package purpose
- document setup module usage

## Testing
- `flake8 backend/analytics/__init__.py setup.py`
- `pydocstyle backend/analytics/__init__.py setup.py`
- `mypy backend/analytics/__init__.py setup.py`
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6879a64435948331a0758702fd2afa02