### PR TITLE
Fix flake8 rules in daily summary script

### DIFF
--- a/scripts/daily_summary.py
+++ b/scripts/daily_summary.py
@@ -1,24 +1,14 @@
 #!/usr/bin/env python
-# flake8: noqa
 """Generate a daily summary report for desAInz."""
 
 from __future__ import annotations
 
-from collections import defaultdict
-from datetime import datetime, timedelta, timezone
-from typing import Mapping
-
 import sys
 from pathlib import Path
 
-sys.path.append(
-    str(
-        Path(__file__).resolve().parents[1]
-        / "backend"
-        / "marketplace-publisher"
-        / "src"
-    )
-)
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Mapping
 
 from sqlalchemy import func, select
 
@@ -45,6 +35,14 @@ def _mockups_count(since: datetime) -> int:
 async def _marketplace_stats(since: datetime) -> Mapping[str, int]:
     """Return count of successful publish tasks per marketplace."""
     stats: dict[str, int] = defaultdict(int)
+    sys.path.append(
+        str(
+            Path(__file__).resolve().parents[1]
+            / "backend"
+            / "marketplace-publisher"
+            / "src"
+        )
+    )
     from marketplace_publisher.db import (
         PublishStatus,
         PublishTask,


### PR DESCRIPTION
## Summary
- remove file level `flake8: noqa`
- adjust imports to avoid E402
- update `_marketplace_stats` to modify `sys.path` lazily

## Testing
- `flake8 scripts/daily_summary.py`
- `pydocstyle scripts/daily_summary.py`
- `mypy --follow-imports=skip scripts/daily_summary.py`
- `docformatter --in-place scripts/daily_summary.py`
- `black scripts/daily_summary.py`
- `pytest tests/test_daily_summary.py -q` *(fails: OperationalError no such table: ideas)*

------
https://chatgpt.com/codex/tasks/task_b_6879a6542a4083319ae216c8a8514de9